### PR TITLE
Add AM_PROG_CC_C_O for configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,7 @@ AC_CONFIG_HEADERS([config.h])
 
 # Checks for programs.
 AC_PROG_CC
-
+AM_PROG_CC_C_O
 # Checks for libraries.
 
 # Checks for header files.


### PR DESCRIPTION
Run autogen.sh on CentOS7, got some errors:
```sh
# ./autogen.sh 

Generating build-system with:
  aclocal:  aclocal (GNU automake) 1.13.4
  autoconf:  autoconf (GNU Autoconf) 2.69
  autoheader:  autoheader (GNU Autoconf) 2.69
  automake:  automake (GNU automake) 1.13.4

automake: warnings are treated as errors
build/Makefile.am:2: warning: compiling '../src/net.c' in subdir requires 'AM_PROG_CC_C_O' in 'configure.ac'
```

Signed-off-by: Ye Yin <eyniy@qq.com>