### PR TITLE
add symlink /dev/{stdin,stdout,stderr} to /proc/self/fd/{0,1,2}

### DIFF
--- a/src/container.c
+++ b/src/container.c
@@ -389,6 +389,11 @@ static int hyper_container_init(void *data)
 		goto fail;
 	}
 
+	symlink("/proc/self/fd", "/dev/fd");
+	symlink("/proc/self/fd/0", "/dev/stdin");
+	symlink("/proc/self/fd/1", "/dev/stdout");
+	symlink("/proc/self/fd/2", "/dev/stderr");
+
 	execvp(container->exec.argv[0], container->exec.argv);
 	perror("exec container command failed");
 


### PR DESCRIPTION
This is what docker does, and will fix the other part of the issue of
official nginx image problems

Test result:

```
gnawux@sonic:~/go/src/github.com/hyperhq/hyper$ ./hyper run nginx
POD id is pod-SwBxHnRdKH
192.168.123.1 - - [03/Oct/2015:07:06:27 +0000] "GET / HTTP/1.1" 200 612 "-" "curl/7.35.0" "-"
```

The curl in another term:

```
gnawux@sonic:~/c/hyperstart/build$ curl http://192.168.123.7/
<!DOCTYPE html>
<html>
<head>
<title>Welcome to nginx!</title>
<style>
    body {
        width: 35em;
        margin: 0 auto;
        font-family: Tahoma, Verdana, Arial, sans-serif;
    }
</style>
</head>
<body>
<h1>Welcome to nginx!</h1>
<p>If you see this page, the nginx web server is successfully installed and
working. Further configuration is required.</p>

<p>For online documentation and support please refer to
<a href="http://nginx.org/">nginx.org</a>.<br/>
Commercial support is available at
<a href="http://nginx.com/">nginx.com</a>.</p>

<p><em>Thank you for using nginx.</em></p>
</body>
</html>
```
