### PR TITLE
add support of separate stderr output of container

### DIFF
--- a/src/exec.h
+++ b/src/exec.h
@@ -7,14 +7,17 @@
 struct hyper_exec {
 	struct list_head	list;
 	struct hyper_event	e;
+	struct hyper_event  errev;
 	char			*id;
 	char			**argv;
 	int			argc;
 	uint64_t		seq;
+	uint64_t		errseq;
 	int			pid;
 	int			ptyno;
 	int			init;
 	int			ptyfd;
+	int			errfd;
 	uint8_t			code;
 	uint8_t			exit;
 };

--- a/src/parse.c
+++ b/src/parse.c
@@ -201,6 +201,8 @@ static int hyper_parse_container(struct hyper_pod *pod, struct hyper_container *
 	c->exec.code = -1;
 	c->exec.e.fd = -1;
 	c->exec.ptyfd = -1;
+	c->exec.seq = 0;
+	c->exec.errseq = 0;
 	c->ns = -1;
 
 	next_container = toks[i].size;
@@ -228,6 +230,10 @@ static int hyper_parse_container(struct hyper_pod *pod, struct hyper_container *
 			i++;
 			c->exec.seq = json_token_ll(json, &toks[i]);
 			fprintf(stdout, "container seq %" PRIu64 "\n", c->exec.seq);
+		} else if (json_token_streq(json, t, "stderr") && t->size == 1) {
+			i++;
+			c->exec.errseq = json_token_ll(json, &toks[i]);
+			fprintf(stdout, "container stderr seq %" PRIu64 "\n", c->exec.errseq);
 		} else if (json_token_streq(json, t, "workdir") && t->size == 1) {
 			i++;
 			c->workdir = strdup(json_token_str(json, &toks[i]));
@@ -580,6 +586,7 @@ realloc:
 
 	exec->ptyfd = -1;
 	exec->e.fd = -1;
+	exec->errseq = 0;
 	INIT_LIST_HEAD(&exec->list);
 
 	for (i = 0, j = 0; i < n; i++) {


### PR DESCRIPTION
this patch add a pipe besides the pty for container, and the stderr will be
sent from the stderr session if the session provided in spec.

this intend to support log the stdout and stderr separately.
