### PR TITLE
Update init.c For allow share_tag a empty string

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -568,7 +568,7 @@ static int hyper_setup_shared(struct hyper_pod *pod)
 {
 	struct vbsf_mount_info_new mntinf;
 
-	if (pod->share_tag == NULL) {
+	if (pod->share_tag == NULL || strlen(pod->share_tag) == 0) {
 		fprintf(stdout, "no shared directroy\n");
 		return 0;
 	}
@@ -599,7 +599,7 @@ static int hyper_setup_shared(struct hyper_pod *pod)
 #else
 static int hyper_setup_shared(struct hyper_pod *pod)
 {
-	if (pod->share_tag == NULL) {
+	if (pod->share_tag == NULL || strlen(pod->share_tag) == 0) {
 		fprintf(stdout, "no shared directroy\n");
 		return 0;
 	}


### PR DESCRIPTION
allow share_tag a empty string, if it's no need to have a share_dir, we could just give it a empty string from hyper.