### PR TITLE
define setns syscall wrapper to fix build issue

### DIFF
--- a/src/container.c
+++ b/src/container.c
@@ -17,6 +17,7 @@
 #include "util.h"
 #include "hyper.h"
 #include "parse.h"
+#include "syscall.h"
 
 static int container_setup_volume(struct hyper_container *container)
 {

--- a/src/exec.c
+++ b/src/exec.c
@@ -12,11 +12,11 @@
 #include <signal.h>
 #include <fcntl.h>
 #include <inttypes.h>
-#include "syscall.h"
 
 #include "hyper.h"
 #include "util.h"
 #include "parse.h"
+#include "syscall.h"
 
 static void pts_hup(struct hyper_event *de, int efd, int out)
 {

--- a/src/init.c
+++ b/src/init.c
@@ -27,6 +27,7 @@
 #include "event.h"
 #include "parse.h"
 #include "container.h"
+#include "syscall.h"
 
 struct hyper_pod global_pod = {
 	.containers	=	LIST_HEAD_INIT(global_pod.containers),

--- a/src/syscall.h
+++ b/src/syscall.h
@@ -1,0 +1,16 @@
+#define _GNU_SOURCE
+#include <unistd.h>
+#include <sys/syscall.h>
+
+/*
+ * Use raw syscall for versions of glibc that don't include it. But this
+ * requires kernel-headers for syscall number hint.
+ */
+
+#if !defined SYS_setns && defined __NR_setns
+static inline int setns(int fd, int nstype)
+{
+	errno = syscall(__NR_setns, fd, nstype);
+	return errno == 0 ? 0 : -1;
+}
+#endif


### PR DESCRIPTION
For example on centos6.x, glibc doesn't contain setns syscall wrapper,
but kernel has setns. We can write a wrapper to simulate the glibc
behavior to fix compile issue.

NOTE: In such case, we will need kernel-headers to get syscall number.

Signed-off-by: WANG Chao <wcwxyz@gmail.com>