### PR TITLE
Use configure script to check setns function

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,7 @@ AC_TYPE_UINT8_T
 # Checks for library functions.
 AC_FUNC_FORK
 AC_CHECK_FUNCS([dup2 memmove memset mkdir setenv socket strchr strdup strrchr strtoul], [fail=0], [fail=1])
+AC_CHECK_FUNCS([setns])
 
 if test "$fail" = "1" ; then
     AC_MSG_ERROR(Unable to find necessary functions)

--- a/src/syscall.h
+++ b/src/syscall.h
@@ -7,7 +7,7 @@
  * requires kernel-headers for syscall number hint.
  */
 
-#if !defined SYS_setns && defined __NR_setns
+#if !defined(HAVE_SETNS) && defined(__NR_setns)
 static inline int setns(int fd, int nstype)
 {
 	errno = syscall(__NR_setns, fd, nstype);


### PR DESCRIPTION
I happen to find out on centos6.7, glibc-headers does have SYS_setns
defined, but previous release doesn't.

It's better to use configure script to check setns function.

Signed-off-by: WANG Chao <wcwxyz@gmail.com>