### PR TITLE
add missing exit(0) to hyper_cmd_online_cpu_mem()

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -1008,6 +1008,7 @@ static void hyper_cmd_online_cpu_mem()
 	} else if (pid == 0) {
 		online_cpu();
 		online_memory();
+		exit(0);
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Lai Jiangshan <jiangshanlai@gmail.com>