### PR TITLE
remove O_NONBLOCK from stderr

### DIFF
--- a/src/exec.c
+++ b/src/exec.c
@@ -175,10 +175,11 @@ int hyper_setup_exec_tty(struct hyper_exec *e)
 
 	if (e->errseq > 0) {
 		int errpipe[2];
-		if (pipe2(errpipe, O_NONBLOCK|O_CLOEXEC) < 0) {
+		if (pipe2(errpipe, O_CLOEXEC) < 0) {
 			fprintf(stderr, "creating stderr pipe failed\n");
 			return -1;
 		}
+		hyper_setfd_nonblock(errpipe[0]);
 		e->errev.fd = errpipe[0];
 		e->errfd = errpipe[1];
 	}


### PR DESCRIPTION
step1: start a container without tty
	hyper run ubuntu
step2: get the fdinfo of the stderr
	cat /proc/self/fdinfo/2
	pos:	0
	flags:	04001
	mnt_id:	8
it shows that the stderr has the O_NONBLOCK flags,
we should remove it.

Signed-off-by: Lai Jiangshan <jiangshanlai@gmail.com>