### PR TITLE
use pipes for stdio when non tty

### DIFF
--- a/src/container.c
+++ b/src/container.c
@@ -567,8 +567,9 @@ fail:
 	close(arg.pipe[0]);
 	close(arg.pipe[1]);
 	close(container->ns);
-	hyper_reset_event(&container->exec.e);
-	hyper_reset_event(&container->exec.errev);
+	hyper_reset_event(&container->exec.stdinev);
+	hyper_reset_event(&container->exec.stdoutev);
+	hyper_reset_event(&container->exec.stderrev);
 	container->ns = -1;
 	fprintf(stdout, "container %s init exit code %d\n", container->id, -1);
 	container->exec.code = -1;

--- a/src/event.c
+++ b/src/event.c
@@ -230,10 +230,10 @@ int hyper_handle_event(int efd, struct epoll_event *event)
 			__func__, event->events, de, de->fd, de->ops);
 
 	/* do not handle hup event if have in event */
-	if (event->events & EPOLLIN) {
+	if ((event->events & EPOLLIN) && de->ops->read) {
 		fprintf(stdout, "%s event EPOLLIN, de %p, fd %d, %p\n",
 			__func__, de, de->fd, de->ops);
-		if (de->ops->read(de, efd) < 0)
+		if (de->ops->read && de->ops->read(de, efd) < 0)
 			return -1;
 	} else if (event->events & EPOLLHUP) {
 		fprintf(stdout, "%s event EPOLLHUP, de %p, fd %d, %p\n",

--- a/src/event.c
+++ b/src/event.c
@@ -252,7 +252,9 @@ int hyper_handle_event(int efd, struct epoll_event *event)
 
 	if (event->events & EPOLLERR) {
 		fprintf(stderr, "get epoll err of not epool in event\n");
-		return -1;
+		if (de->ops->hup)
+			de->ops->hup(de, efd);
+		return 0;
 	}
 
 	return 0;

--- a/src/exec.c
+++ b/src/exec.c
@@ -261,11 +261,6 @@ int hyper_dup_exec_tty(int to, struct hyper_exec *e)
 
 	fd = e->ptyfd;
 
-	if (fd < 0) {
-		perror("open pty device for execcmd failed");
-		goto out;
-	}
-
 	if (e->tty && (ioctl(fd, TIOCSCTTY, NULL) < 0)) {
 		perror("ioctl pty device for execcmd failed");
 		goto out;
@@ -284,16 +279,9 @@ int hyper_dup_exec_tty(int to, struct hyper_exec *e)
 		goto out;
 	}
 
-	if (e->errseq > 0) {
-		if (dup2(e->errfd, STDERR_FILENO) < 0) {
-			perror("dup err pipe to stderr failed");
-			goto out;
-		}
-	} else {
-		if (dup2(fd, STDERR_FILENO) < 0) {
-			perror("dup tty device to stderr failed");
-			goto out;
-		}
+	if (dup2(e->errfd, STDERR_FILENO) < 0) {
+		perror("dup err pipe to stderr failed");
+		goto out;
 	}
 
 	ret = 0;

--- a/src/exec.h
+++ b/src/exec.h
@@ -6,8 +6,9 @@
 
 struct hyper_exec {
 	struct list_head	list;
-	struct hyper_event	e;
-	struct hyper_event	errev;
+	struct hyper_event	stdinev;
+	struct hyper_event	stdoutev;
+	struct hyper_event	stderrev;
 	char			*id;
 	char			**argv;
 	int			argc;

--- a/src/exec.h
+++ b/src/exec.h
@@ -18,7 +18,9 @@ struct hyper_exec {
 	int			ptyno;
 	int			init;
 	int			ptyfd;
-	int			errfd;
+	int			stdinfd;
+	int			stdoutfd;
+	int			stderrfd;
 	uint8_t			code;
 	uint8_t			exit;
 	uint8_t			ref;

--- a/src/init.c
+++ b/src/init.c
@@ -1059,7 +1059,7 @@ static int hyper_ttyfd_handle(struct hyper_event *de, uint32_t len)
 		return 0;
 	}
 
-	wbuf = &exec->e.wbuf;
+	wbuf = &exec->stdinev.wbuf;
 
 	size = wbuf->size - wbuf->get;
 	if (size == 0)
@@ -1073,7 +1073,7 @@ static int hyper_ttyfd_handle(struct hyper_event *de, uint32_t len)
 	if (size > 0) {
 		memcpy(wbuf->data + wbuf->get, rbuf->data + 12, size);
 		wbuf->get += size;
-		if (hyper_modify_event(ctl.efd, &exec->e, EPOLLIN | EPOLLOUT) < 0) {
+		if (hyper_modify_event(ctl.efd, &exec->stdinev, EPOLLOUT) < 0) {
 			fprintf(stderr, "modify exec pts event to in & out failed\n");
 			return -1;
 		}

--- a/src/parse.c
+++ b/src/parse.c
@@ -469,8 +469,9 @@ static int hyper_parse_container(struct hyper_pod *pod, struct hyper_container *
 
 	c->exec.init = 1;
 	c->exec.code = -1;
-	c->exec.e.fd = -1;
-	c->exec.errev.fd = -1;
+	c->exec.stdinev.fd = -1;
+	c->exec.stdoutev.fd = -1;
+	c->exec.stderrev.fd = -1;
 	c->exec.ptyfd = -1;
 	c->exec.stdinfd = -1;
 	c->exec.stdoutfd = -1;
@@ -1032,8 +1033,9 @@ realloc:
 	exec->stdinfd = -1;
 	exec->stdoutfd = -1;
 	exec->stderrfd = -1;
-	exec->e.fd = -1;
-	exec->errev.fd = -1;
+	exec->stdinev.fd = -1;
+	exec->stdoutev.fd = -1;
+	exec->stderrev.fd = -1;
 	INIT_LIST_HEAD(&exec->list);
 
 	for (i = 0, j = 0; i < n; i++) {

--- a/src/parse.c
+++ b/src/parse.c
@@ -472,7 +472,9 @@ static int hyper_parse_container(struct hyper_pod *pod, struct hyper_container *
 	c->exec.e.fd = -1;
 	c->exec.errev.fd = -1;
 	c->exec.ptyfd = -1;
-	c->exec.errfd = -1;
+	c->exec.stdinfd = -1;
+	c->exec.stdoutfd = -1;
+	c->exec.stderrfd = -1;
 	c->ns = -1;
 	INIT_LIST_HEAD(&c->list);
 
@@ -1027,7 +1029,9 @@ realloc:
 	}
 
 	exec->ptyfd = -1;
-	exec->errfd = -1;
+	exec->stdinfd = -1;
+	exec->stdoutfd = -1;
+	exec->stderrfd = -1;
 	exec->e.fd = -1;
 	exec->errev.fd = -1;
 	INIT_LIST_HEAD(&exec->list);


### PR DESCRIPTION
split exec.e into exec.stdinev and exec.stdoutev  …
and rename exec.errev to exec.stderrev
and make stdinev.fd stdoutev.fd stderrev.fd are valid but different
and register all these events