### PR TITLE
Set the rootfs of the namespace to be the rootfs of the container

### DIFF
--- a/src/container.c
+++ b/src/container.c
@@ -326,7 +326,7 @@ static int hyper_container_init(void *data)
 {
 	struct hyper_container_arg *arg = data;
 	struct hyper_container *container = arg->c;
-	char root[512], oldroot[512];
+	char root[512], oldroot[512], rootfs[512];
 
 	fprintf(stdout, "%s in\n", __func__);
 	if (container->exec.argv == NULL) {
@@ -418,15 +418,20 @@ static int hyper_container_init(void *data)
 		perror("bind oldroot failed");
 		goto fail;
 	}
-	/* reuse oldroot array */
-	sprintf(oldroot, "%s/%s/", root, container->rootfs);
-	if (mount(oldroot, oldroot, NULL, MS_BIND|MS_REC, NULL) < 0) {
+
+	sprintf(rootfs, "%s/%s/", root, container->rootfs);
+	if (mount(rootfs, rootfs, NULL, MS_BIND|MS_REC, NULL) < 0) {
 		perror("failed to bind rootfs");
+		goto fail;
+	}
+	chdir(rootfs);
+	if (mount(rootfs, "/", NULL, MS_MOVE, NULL) < 0) {
+		perror("failed to move rootfs");
 		goto fail;
 	}
 	/* pivot_root won't work, see
 	 * Documention/filesystem/ramfs-rootfs-initramfs.txt */
-	chroot(oldroot);
+	chroot(".");
 
 	chdir("/");
 

--- a/src/exec.c
+++ b/src/exec.c
@@ -410,16 +410,7 @@ int hyper_enter_container(struct hyper_pod *pod,
 		goto out;
 	}
 
-	sprintf(path, "/tmp/hyper/%s/root/%s/", c->id, c->rootfs);
-	fprintf(stdout, "root directory for container is %s, exec %s\n",
-		path, exec->argv[0]);
-
 	/* TODO: wait for container finishing setup root */
-	if (chroot(path) < 0) {
-		perror("chroot for exec command failed");
-		goto out;
-	}
-
 	chdir("/");
 
 	ret = hyper_setup_env(c->envs, c->envs_num);

--- a/src/init.c
+++ b/src/init.c
@@ -734,19 +734,13 @@ static int hyper_cmd_write_file(char *json, int length)
 		goto out;
 	}
 
+	/* TODO: wait for container finishing setup root */
 	if (setns(mntns, CLONE_NEWNS) < 0) {
 		perror("fail to enter container ns");
 		goto exit;
 	}
 
-	sprintf(path, "/tmp/hyper/%s/root/%s/", c->id, c->rootfs);
 	fprintf(stdout, "write file %s, data len %d\n", writter.file, writter.len);
-
-	/* TODO: wait for container finishing setup root */
-	if (chroot(path) < 0) {
-		perror("chroot for exec command failed");
-		goto exit;
-	}
 
 	fd = open(writter.file, O_CREAT| O_TRUNC| O_WRONLY, 0644);
 	if (fd < 0) {
@@ -796,18 +790,13 @@ static int hyper_do_cmd_read_file(void *data)
 	int len = 0, size, fd, ret = -1;
 	struct hyper_file_arg *arg = data;
 
+	/* TODO: wait for container finishing setup root */
 	if (setns(arg->mntns, CLONE_NEWNS) < 0) {
 		perror("fail to enter container ns");
 		goto err;
 	}
 
 	fprintf(stdout, "read file %s\n", arg->file);
-
-	/* TODO: wait for container finishing setup root */
-	if (chroot(arg->root) < 0) {
-		perror("chroot for exec command failed");
-		goto err;
-	}
 
 	if (stat(arg->file, &st) < 0) {
 		perror("fail to state file");
@@ -888,7 +877,6 @@ static int hyper_cmd_read_file(char *json, int length, uint32_t *datalen, uint8_
 	arg.file = reader.file;
 	arg.datalen = datalen;
 	arg.data = data;
-	sprintf(arg.root, "/tmp/hyper/%s/root/%s/", c->id, c->rootfs);
 
 	stack = malloc(stacksize);
 	if (stack == NULL) {


### PR DESCRIPTION


we use MS_MOVE to move the container rootfs to /, so that the rootfs
of the namespace and the rootfs of the container are the same.

Signed-off-by: Lai Jiangshan <jiangshanlai@gmail.com>