### PR TITLE
fix symlink leek

### DIFF
--- a/src/exec.c
+++ b/src/exec.c
@@ -318,6 +318,9 @@ int hyper_dup_exec_tty(int to, struct hyper_exec *e)
 		e->stdoutfd = e->ptyfd;
 		if (e->errseq == 0)
 			e->stderrfd = e->ptyfd;
+		close(e->stdinev.fd);
+		close(e->stdoutev.fd);
+		close(e->stderrev.fd);
 	}
 
 	fflush(stdout);


### PR DESCRIPTION
reopen slave ptyfd for correcting the symlink path of the /dev/fd/1

before patch:
root@ubuntu-4562002641:/# readlink /dev/fd/1
/tmp/hyper/656f914cd9c030214bf95aff8f3bf418c1c277f5b82a661a27a174c9c8ce901b/devpts/3

after patch:
root@ubuntu-5512501784:/# readlink /dev/fd/1
/dev/pts/1