### PR TITLE
Setup mounts&rootfs before chroot

### DIFF
--- a/src/container.c
+++ b/src/container.c
@@ -60,7 +60,7 @@ static int container_setup_volume(struct hyper_container *container)
 		vol = &container->vols[i];
 
 		if (vol->scsiaddr)
-			hyper_find_sd("", vol->scsiaddr, &vol->device);
+			hyper_find_sd(vol->scsiaddr, &vol->device);
 
 		sprintf(dev, "/dev/%s", vol->device);
 		sprintf(path, "/tmp/%s", vol->mountpoint);
@@ -407,7 +407,7 @@ static int hyper_container_init(void *data)
 		char dev[128];
 
 		if (container->scsiaddr)
-			hyper_find_sd("", container->scsiaddr, &container->image);
+			hyper_find_sd(container->scsiaddr, &container->image);
 
 		sprintf(dev, "/dev/%s", container->image);
 		fprintf(stdout, "device %s\n", dev);

--- a/src/util.c
+++ b/src/util.c
@@ -99,13 +99,13 @@ int hyper_copy_dir(char *src, char *dest) {
 	return 0;
 }
 
-int hyper_find_sd(char *prefix, char *addr, char **dev) {
+int hyper_find_sd(char *addr, char **dev) {
 	struct dirent **list;
 	struct dirent *dir;
 	char path[512];
 	int i, num;
 
-	sprintf(path, "%s/sys/class/scsi_disk/0:0:%s/device/block/", prefix, addr);
+	sprintf(path, "/sys/class/scsi_disk/0:0:%s/device/block/", addr);
 	fprintf(stdout, "orig dev %s, scan path %s\n", *dev, path);
 
 	num = scandir(path, &list, NULL, NULL);

--- a/src/util.h
+++ b/src/util.h
@@ -16,7 +16,7 @@ struct env;
 
 char *read_cmdline(void);
 int hyper_setup_env(struct env *envs, int num);
-int hyper_find_sd(char *prefix, char *addr, char **dev);
+int hyper_find_sd(char *addr, char **dev);
 int hyper_list_dir(char *path);
 int hyper_copy_dir(char *src, char *dst);
 void online_cpu(void);


### PR DESCRIPTION
we learned from runc, it setups the whole rootfs (mount everything)
and then manipulate(move to) the / and chroot. (libcontainer/rootfs_linux.go)

hyperstart also mounts everything and then move the /.
And the /.oldroot/ is unneeded.