### PR TITLE
Fix exec part1 cleanup

### DIFF
--- a/src/container.c
+++ b/src/container.c
@@ -197,6 +197,11 @@ static int container_setup_mount(struct hyper_container *container)
 	if (symlink("/dev/pts/ptmx", "./dev/ptmx") < 0)
 		perror("link /dev/pts/ptmx to /dev/ptmx failed");
 
+	symlink("/proc/self/fd", "./dev/fd");
+	symlink("/proc/self/fd/0", "./dev/stdin");
+	symlink("/proc/self/fd/1", "./dev/stdout");
+	symlink("/proc/self/fd/2", "./dev/stderr");
+
 	return 0;
 }
 
@@ -540,11 +545,6 @@ static int hyper_container_init(void *data)
 		fprintf(stdout, "setup tty failed\n");
 		goto fail;
 	}
-
-	symlink("/proc/self/fd", "/dev/fd");
-	symlink("/proc/self/fd/0", "/dev/stdin");
-	symlink("/proc/self/fd/1", "/dev/stdout");
-	symlink("/proc/self/fd/2", "/dev/stderr");
 
 	execvp(container->exec.argv[0], container->exec.argv);
 	perror("exec container command failed");

--- a/src/container.c
+++ b/src/container.c
@@ -336,10 +336,10 @@ static int container_setup_workdir(struct hyper_container *container)
 {
 	if (container->initialize) {
 		// create workdir
-		hyper_mkdir(container->workdir);
+		hyper_mkdir(container->exec.workdir);
 	}
 
-	if (container->workdir && chdir(container->workdir) < 0) {
+	if (container->exec.workdir && chdir(container->exec.workdir) < 0) {
 		perror("change work directory failed");
 		return -1;
 	}

--- a/src/container.c
+++ b/src/container.c
@@ -440,7 +440,7 @@ static int hyper_container_init(void *data)
 	else
 		unsetenv("TERM");
 
-	if (hyper_setup_env(container->envs, container->envs_num) < 0) {
+	if (hyper_setup_env(container->exec.envs, container->exec.envs_num) < 0) {
 		fprintf(stdout, "setup env failed\n");
 		goto fail;
 	}

--- a/src/container.h
+++ b/src/container.h
@@ -3,11 +3,6 @@
 
 #include "exec.h"
 
-struct env {
-	char	*env;
-	char	*value;
-};
-
 struct volume {
 	char	*device;
 	char	*scsiaddr;
@@ -36,11 +31,9 @@ struct hyper_container {
 	char			*scsiaddr;
 	char			*fstype;
 	struct volume		*vols;
-	struct env		*envs;
 	struct fsmap		*maps;
 	struct sysctl		*sys;
 	int			vols_num;
-	int			envs_num;
 	int			maps_num;
 	int			sys_num;
 	int			ns;

--- a/src/container.h
+++ b/src/container.h
@@ -34,7 +34,6 @@ struct hyper_container {
 	char			*rootfs;
 	char			*image;
 	char			*scsiaddr;
-	char			*workdir;
 	char			*fstype;
 	struct volume		*vols;
 	struct env		*envs;

--- a/src/exec.c
+++ b/src/exec.c
@@ -227,8 +227,8 @@ int hyper_setup_exec_tty(struct hyper_exec *e)
 	char ptmx[512], path[512];
 
 	if (e->seq == 0) {
-		e->ptyfd = open("/dev/null", O_RDWR | O_NOCTTY | O_CLOEXEC);
-		goto done;
+		fprintf(stderr, "e->seq should be set\n");
+		return -1;
 	}
 
 	if (!e->tty) { // don't use tty for stdio
@@ -289,7 +289,6 @@ int hyper_setup_exec_tty(struct hyper_exec *e)
 
 	e->stdinev.fd = ptymaster;
 	e->stdoutev.fd = dup(ptymaster);
-done:
 	if (e->errseq == 0) {
 		e->stderrev.fd = dup(e->stdoutev.fd);
 	}

--- a/src/exec.c
+++ b/src/exec.c
@@ -421,7 +421,9 @@ int hyper_enter_container(struct hyper_pod *pod,
 	/* TODO: wait for container finishing setup root */
 	chdir("/");
 
-	ret = hyper_setup_env(c->envs, c->envs_num);
+	if (hyper_setup_env(c->exec.envs, c->exec.envs_num) < 0)
+		goto out;
+	ret = hyper_setup_env(exec->envs, exec->envs_num);
 out:
 	close(ipcns);
 	close(utsns);

--- a/src/exec.h
+++ b/src/exec.h
@@ -9,12 +9,6 @@ struct hyper_exec {
 	struct hyper_event	stdinev;
 	struct hyper_event	stdoutev;
 	struct hyper_event	stderrev;
-	char			*id;
-	char			**argv;
-	int			argc;
-	int			tty; // use tty or not
-	uint64_t		seq;
-	uint64_t		errseq;
 	int			pid;
 	int			ptyno;
 	int			init;
@@ -26,6 +20,15 @@ struct hyper_exec {
 	uint8_t			code;
 	uint8_t			exit;
 	uint8_t			ref;
+
+	// configs
+	char			*id;
+	char			**argv;
+	int			argc;
+	int			tty; // use tty or not
+	uint64_t		seq;
+	uint64_t		errseq;
+	char			*workdir;
 };
 
 struct hyper_pod;

--- a/src/exec.h
+++ b/src/exec.h
@@ -4,6 +4,11 @@
 #include "list.h"
 #include "event.h"
 
+struct env {
+	char	*env;
+	char	*value;
+};
+
 struct hyper_exec {
 	struct list_head	list;
 	struct hyper_event	stdinev;
@@ -23,6 +28,8 @@ struct hyper_exec {
 
 	// configs
 	char			*id;
+	struct env		*envs;
+	int			envs_num;
 	char			**argv;
 	int			argc;
 	int			tty; // use tty or not

--- a/src/init.c
+++ b/src/init.c
@@ -143,7 +143,7 @@ static void hyper_term_all(struct hyper_pod *pod)
 	DIR *dp;
 	struct dirent *de;
 	pid_t *pids = NULL;
-	struct hyper_container *c;
+	struct hyper_exec *e;
 
 	dp = opendir("/proc");
 	if (dp == NULL)
@@ -175,8 +175,8 @@ static void hyper_term_all(struct hyper_pod *pod)
 	free(pids);
 	closedir(dp);
 
-	list_for_each_entry(c, &pod->containers, list)
-		hyper_kill_process(c->exec.pid);
+	list_for_each_entry(e, &pod->exec_head, list)
+		hyper_kill_process(e->pid);
 }
 
 static int hyper_handle_exit(struct hyper_pod *pod)

--- a/src/init.c
+++ b/src/init.c
@@ -692,7 +692,6 @@ static int hyper_cmd_write_file(char *json, int length)
 	struct hyper_pod *pod = &global_pod;
 	int pipe[2] = {-1, -1};
 	int pid, mntns = -1, fd;
-	char path[512];
 	int len = 0, size, ret = -1;
 
 	fprintf(stdout, "%s\n", __func__);

--- a/src/parse.c
+++ b/src/parse.c
@@ -164,6 +164,9 @@ static void container_cleanup_exec(struct hyper_exec *exec)
 	free(exec->id);
 	exec->id = NULL;
 
+	free(exec->workdir);
+	exec->workdir = NULL;
+
 	for (i = 0; i < exec->argc; i++) {
 		free(exec->argv[i]);
 	}
@@ -441,9 +444,6 @@ void hyper_free_container(struct hyper_container *c)
 	free(c->scsiaddr);
 	c->scsiaddr = NULL;
 
-	free(c->workdir);
-	c->workdir = NULL;
-
 	free(c->fstype);
 	c->fstype = NULL;
 
@@ -524,8 +524,8 @@ static int hyper_parse_container(struct hyper_pod *pod, struct hyper_container *
 			fprintf(stdout, "container stderr seq %" PRIu64 "\n", c->exec.errseq);
 			i++;
 		} else if (json_token_streq(json, t, "workdir") && t->size == 1) {
-			c->workdir = (json_token_str(json, &toks[++i]));
-			fprintf(stdout, "container workdir %s\n", c->workdir);
+			c->exec.workdir = (json_token_str(json, &toks[++i]));
+			fprintf(stdout, "container workdir %s\n", c->exec.workdir);
 			i++;
 		} else if (json_token_streq(json, t, "image") && t->size == 1) {
 			c->image = (json_token_str(json, &toks[++i]));


### PR DESCRIPTION
cleanups on hyperstart
move exec related configs to struct hyper_exec
kill all exec rather than only container in hyper_term_all()