### PR TITLE
xfs needs nouuid mount option

### DIFF
--- a/src/container.c
+++ b/src/container.c
@@ -57,6 +57,7 @@ static int container_setup_volume(struct hyper_container *container)
 	for (i = 0; i < container->vols_num; i++) {
 		char volume[512];
 		char mountpoint[512];
+		char *options = NULL;
 		vol = &container->vols[i];
 
 		if (vol->scsiaddr)
@@ -75,7 +76,10 @@ static int container_setup_volume(struct hyper_container *container)
 			return -1;
 		}
 
-		if (mount(dev, path, vol->fstype, 0, NULL) < 0) {
+		if (!strncmp(vol->fstype, "xfs", strlen("xfs")))
+			options = "nouuid";
+
+		if (mount(dev, path, vol->fstype, 0, options) < 0) {
 			perror("mount volume device faled");
 			return -1;
 		}
@@ -467,6 +471,7 @@ static int hyper_container_init(void *data)
 
 	if (container->fstype) {
 		char dev[128];
+		char *options = NULL;
 
 		if (container->scsiaddr)
 			hyper_find_sd(container->scsiaddr, &container->image);
@@ -474,7 +479,10 @@ static int hyper_container_init(void *data)
 		sprintf(dev, "/dev/%s", container->image);
 		fprintf(stdout, "device %s\n", dev);
 
-		if (mount(dev, root, container->fstype, 0, NULL) < 0) {
+		if (!strncmp(container->fstype, "xfs", strlen("xfs")))
+			options = "nouuid";
+
+		if (mount(dev, root, container->fstype, 0, options) < 0) {
 			perror("mount device failed");
 			goto fail;
 		}


### PR DESCRIPTION
Otherwise devicemapper/rbd mount might fail due to device UUID
conflicts on snapshot/clone devices.
