### PR TITLE
support file destination volume

### DIFF
--- a/src/hyper.h
+++ b/src/hyper.h
@@ -124,6 +124,7 @@ static inline int hyper_create(char *hyper_path)
 	return 0;
 }
 
+int hyper_create_file(const char *hyper_path);
 int hyper_mkdir(char *hyper_path);
 int hyper_open_serial(char *tty);
 struct hyper_container *hyper_find_container(struct hyper_pod *pod, char *id);

--- a/src/util.c
+++ b/src/util.c
@@ -233,6 +233,26 @@ int hyper_getgrouplist(const char *user, gid_t group, gid_t *groups, int *ngroup
 	return ret;
 }
 
+int hyper_create_file(const char *hyper_path)
+{
+	int fd;
+	struct stat stbuf;
+
+	if (stat(hyper_path, &stbuf) >= 0) {
+		if (S_ISREG(stbuf.st_mode))
+			return 0;
+		errno = S_ISDIR(stbuf.st_mode) ? EISDIR : EINVAL;
+		return -1;
+	}
+
+	fd = open(hyper_path, O_CREAT|O_WRONLY, 0666);
+	if (fd < 0)
+		return -1;
+	close(fd);
+	fprintf(stdout, "created file %s\n", hyper_path);
+	return 0;
+}
+
 int hyper_mkdir(char *hyper_path)
 {
 	struct stat st;


### PR DESCRIPTION
If a volume source contains only one file, bind mount it as a file
to the specified mountpoint inside container's namespace, rather than
mounting its parent directory.

Iff volume source has only one file, and destination mountpoint is not
an existing directory, bind mount the file.