### PR TITLE
send ERROR to runv when shutting down upon errors

### DIFF
--- a/src/exec.c
+++ b/src/exec.c
@@ -777,7 +777,7 @@ int hyper_release_exec(struct hyper_exec *exec,
 			hyper_send_msg_block(ctl.chan.fd, ACK, 0, NULL);
 		} else if (pod->type == DESTROYPOD) {
 			/* shutdown vm manually, hyper doesn't care the pod finished codes */
-			hyper_shutdown();
+			hyper_shutdown(0);
 		} else {
 			/* send out pod finish message, hyper will decide if restart pod or not */
 			hyper_send_pod_finished(pod);

--- a/src/init.c
+++ b/src/init.c
@@ -481,11 +481,11 @@ static void hyper_print_uptime(void)
 	close(fd);
 }
 
-static int hyper_destroy_pod(struct hyper_pod *pod)
+static int hyper_destroy_pod(struct hyper_pod *pod, int error)
 {
 	if (pod->init_pid == 0) {
 		/* Pod stopped, just shutdown */
-		hyper_shutdown();
+		hyper_shutdown(error);
 	} else {
 		/* Kill pod */
 		hyper_term_all(pod);
@@ -509,13 +509,13 @@ static int hyper_start_pod(char *json, int length)
 	}
 
 	if (hyper_setup_pod(pod) < 0) {
-		hyper_destroy_pod(pod);
+		hyper_destroy_pod(pod, 1);
 		return -1;
 	}
 
 	if (hyper_start_containers(pod) < 0) {
 		fprintf(stderr, "start containers failed\n");
-		hyper_destroy_pod(pod);
+		hyper_destroy_pod(pod, 1);
 		return -1;
 	}
 
@@ -1032,7 +1032,7 @@ static int hyper_channel_handle(struct hyper_event *de, uint32_t len)
 		//break;
 	case DESTROYPOD:
 		fprintf(stdout, "get DESTROYPOD message\n");
-		hyper_destroy_pod(pod);
+		hyper_destroy_pod(pod, 0);
 		return 0;
 	case EXECCMD:
 		ret = hyper_exec_cmd((char *)buf->data + 8, len - 8);

--- a/src/util.c
+++ b/src/util.c
@@ -639,9 +639,9 @@ static void hyper_unmount_all(void)
 	sync();
 }
 
-void hyper_shutdown()
+void hyper_shutdown(int error)
 {
-	hyper_send_msg_block(ctl.chan.fd, ACK, 0, NULL);
+	hyper_send_msg_block(ctl.chan.fd, error?ERROR:ACK, 0, NULL);
 	hyper_unmount_all();
 	reboot(LINUX_REBOOT_CMD_POWER_OFF);
 }

--- a/src/util.h
+++ b/src/util.h
@@ -32,7 +32,7 @@ int hyper_setfd_cloexec(int fd);
 int hyper_setfd_block(int fd);
 int hyper_setfd_nonblock(int fd);
 int hyper_socketpair(int domain, int type, int protocol, int sv[2]);
-void hyper_shutdown(void);
+void hyper_shutdown(int ack);
 int hyper_insmod(char *module);
 struct passwd *hyper_getpwnam(const char *name);
 struct group *hyper_getgrnam(const char *name);


### PR DESCRIPTION
Otherwise ACK might let runv think its command succeeds, and thus miss out the error message.

This happens when hyper_pod_init() fails, or container_setup_volume() fails before commit 54aed5efc5e071fe7c7e1baca2fe2e1c4e9e1da6