### PR TITLE
set up volume ownership

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -1211,6 +1211,7 @@ int main(int argc, char *argv[])
 
 	symlink("/busybox", "/sh");
 	symlink("/busybox", "/tar");
+	symlink("/busybox", "/chown");
 	symlink("/busybox", "/sbin/modprobe");
 	symlink("/busybox", "/sbin/depmod");
 	symlink("/iptables", "/sbin/iptables");

--- a/src/util.c
+++ b/src/util.c
@@ -675,3 +675,16 @@ int hyper_cmd(char *cmd)
 
 	return -1;
 }
+
+
+int hyper_chown(const char *path, const char *user, const char *group, int recursive)
+{
+	char cmd[512];
+
+	if (recursive)
+		snprintf(cmd, sizeof(cmd), "/chown -R %s:%s %s", user, group, path);
+	else
+		snprintf(cmd, sizeof(cmd), "/chown %s:%s %s", user, group, path);
+
+	return hyper_cmd(cmd);
+}

--- a/src/util.h
+++ b/src/util.h
@@ -25,6 +25,7 @@ void hyper_sync_time_hctosys();
 void online_cpu(void);
 void online_memory(void);
 int hyper_cmd(char *cmd);
+int hyper_chown(const char *path, const char *user, const char *group, int recursive);
 int hyper_mkdir(char *path);
 int hyper_open_channel(char *channel, int mode);
 int hyper_open_serial_dev(char *tty);


### PR DESCRIPTION
For a new volume, we need to set up volume directory ownership
according to container's exec user/group.

A new volume is identified in two ways:
1. There is no _data directory
2. There is a file _data/.hyper_new_volume_do_not_create_on_your_own