### PR TITLE
set up volume ownership

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -1211,6 +1211,7 @@ int main(int argc, char *argv[])
 
 	symlink("/busybox", "/sh");
 	symlink("/busybox", "/tar");
+	symlink("/busybox", "/chown");
 	symlink("/busybox", "/sbin/modprobe");
 	symlink("/busybox", "/sbin/depmod");
 	symlink("/iptables", "/sbin/iptables");

--- a/src/util.c
+++ b/src/util.c
@@ -660,3 +660,15 @@ int hyper_cmd(char *cmd)
 
 	return -1;
 }
+
+int hyper_chown(const char *path, uid_t user, gid_t group, int recursive)
+{
+	char cmd[512];
+
+	if (recursive)
+		snprintf(cmd, sizeof(cmd), "/chown -R %lu:%lu %s", (unsigned long)user, (unsigned long)group, path);
+	else
+		snprintf(cmd, sizeof(cmd), "/chown %lu:%lu %s", (unsigned long)user, (unsigned long)group, path);
+
+	return hyper_cmd(cmd);
+}

--- a/src/util.c
+++ b/src/util.c
@@ -131,13 +131,12 @@ static unsigned long id_or_max(const char *name)
 	return id;
 }
 
-// the same as getpwnam(), but it only parses /etc/passwd and allows name to be id string
-struct passwd *hyper_getpwnam(const char *name)
+struct passwd *hyper_getpwnam_from(const char *name, const char *pwd_file)
 {
 	uid_t uid = (uid_t)id_or_max(name);
-	FILE *file = fopen("/etc/passwd", "r");
+	FILE *file = fopen(pwd_file, "r");
 	if (!file) {
-		perror("faile to open /etc/passwd");
+		perror("faile to open passwd file");
 		return NULL;
 	}
 	for (;;) {
@@ -153,13 +152,18 @@ struct passwd *hyper_getpwnam(const char *name)
 	return NULL;
 }
 
-// the same as getgrnam(), but it only parses /etc/group and allows the name to be id string
-struct group *hyper_getgrnam(const char *name)
+// the same as getpwnam(), but it only parses /etc/passwd and allows name to be id string
+struct passwd *hyper_getpwnam(const char *name)
+{
+	return hyper_getpwnam_from(name, "/etc/passwd");
+}
+
+struct group *hyper_getgrnam_from(const char *name, const char *group_file)
 {
 	gid_t gid = (gid_t)id_or_max(name);
-	FILE *file = fopen("/etc/group", "r");
+	FILE *file = fopen(group_file, "r");
 	if (!file) {
-		perror("faile to open /etc/group");
+		perror("faile to open group file");
 		return NULL;
 	}
 	for (;;) {
@@ -173,6 +177,12 @@ struct group *hyper_getgrnam(const char *name)
 	}
 	fclose(file);
 	return NULL;
+}
+
+// the same as getgrnam(), but it only parses /etc/group and allows the name to be id string
+struct group *hyper_getgrnam(const char *name)
+{
+	return hyper_getgrnam_from(name, "/etc/group");
 }
 
 // the same as getgrouplist(), but it only parses /etc/group

--- a/src/util.h
+++ b/src/util.h
@@ -34,6 +34,8 @@ int hyper_setfd_nonblock(int fd);
 int hyper_socketpair(int domain, int type, int protocol, int sv[2]);
 void hyper_shutdown(int ack);
 int hyper_insmod(char *module);
+struct passwd *hyper_getpwnam_from(const char *name, const char *pwd_file);
+struct group *hyper_getgrnam_from(const char *name, const char *group_file);
 struct passwd *hyper_getpwnam(const char *name);
 struct group *hyper_getgrnam(const char *name);
 int hyper_getgrouplist(const char *user, gid_t group, gid_t *groups, int *ngroups);

--- a/src/util.h
+++ b/src/util.h
@@ -25,6 +25,7 @@ void hyper_sync_time_hctosys();
 void online_cpu(void);
 void online_memory(void);
 int hyper_cmd(char *cmd);
+int hyper_chown(const char *path, uid_t user, gid_t group, int recursive);
 int hyper_mkdir(char *path);
 int hyper_open_channel(char *channel, int mode);
 int hyper_open_serial_dev(char *tty);


### PR DESCRIPTION
For a new volume, we need to set up volume directory ownership
according to container's exec user/group.

A new volume is identified in two ways:
1. There is no _data directory
2. There is a file _data/.hyper_new_volume_do_not_create_on_your_own