### PR TITLE
Revert "move mount /proc to hyper_container_final_init()"

### DIFF
--- a/src/container.h
+++ b/src/container.h
@@ -33,7 +33,6 @@ struct port {
 struct hyper_container {
 	struct list_head	list;
 	struct hyper_exec	exec;
-	int			finalinit;
 	int			ns;
 	uint32_t		code;
 


### PR DESCRIPTION
running in child process, fail to setup finalinit

This reverts commit b0a601793efc96ca909371b8804edc8aff11b87e.