### PR TITLE
[RFC] fill write buffer of tty channel in the out event of tty channel

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -208,11 +208,6 @@ int hyper_event_write(struct hyper_event *he, int efd)
 
 	buf->get -= len;
 	memmove(buf->data, buf->data + len, buf->get);
-
-	if (buf->get == 0) {
-		hyper_modify_event(ctl.efd, he, EPOLLIN);
-	}
-
 	return 0;
 }
 

--- a/src/list.h
+++ b/src/list.h
@@ -110,6 +110,18 @@ static inline void list_del_init(struct list_head *entry)
 }
 
 /**
+ *  list_move_tail - delete from one list and add as another's tail
+ *  @list: the entry to move
+ *  @head: the head that will follow our entry
+ */
+static inline void list_move_tail(struct list_head *list,
+				  struct list_head *head)
+{
+	list_del_init(list);
+	list_add_tail(list, head);
+}
+
+/**
  * list_empty - tests whether a list is empty
  * @head: the list to test.
  */


### PR DESCRIPTION
in currect, one tty of exec may fill up the write buffer of tty
channel at most time. it's unfair to other exec.
fix this by only handling the first available exec in the out event
of tty channel, and then remove it to the tail.

Signed-off-by: Gao feng <omarapazanadi@gmail.com>