### PR TITLE
enter the sandbox when hyper_setup_container_rootfs()

### DIFF
--- a/src/container.c
+++ b/src/container.c
@@ -269,8 +269,8 @@ static int container_setup_mount(struct hyper_container *container)
 	hyper_mkdir("./dev", 0755);
 	hyper_mkdir("./lib/modules", 0755);
 
-	// mount proc filesystem when the container init process running in the pidns of podinit
-	if (mount("sysfs", "./sys", "sysfs", MS_NOSUID| MS_NODEV| MS_NOEXEC, NULL) < 0 ||
+	if (mount("proc", "./proc", "proc", MS_NOSUID| MS_NODEV| MS_NOEXEC, NULL) < 0 ||
+	    mount("sysfs", "./sys", "sysfs", MS_NOSUID| MS_NODEV| MS_NOEXEC, NULL) < 0 ||
 	    mount("devtmpfs", "./dev", "devtmpfs", MS_NOSUID, NULL) < 0) {
 		perror("mount basic filesystem for container failed");
 		return -1;
@@ -511,6 +511,11 @@ static int hyper_setup_container_rootfs(void *data)
 	char root[512], rootfs[512];
 	int setup_dns;
 	uint32_t type;
+
+	if (hyper_enter_sandbox(arg->pod, -1) < 0) {
+		perror("enter sandbox failed");
+		goto fail;
+	}
 
 	if (hyper_rescan_scsi() < 0) {
 		fprintf(stdout, "rescan scsi failed\n");

--- a/src/exec.c
+++ b/src/exec.c
@@ -8,7 +8,6 @@
 #include <sys/ioctl.h>
 #include <sys/wait.h>
 #include <sys/socket.h>
-#include <sys/mount.h>
 #include <dirent.h>
 #include <sched.h>
 #include <errno.h>
@@ -516,12 +515,6 @@ static int hyper_do_exec_cmd(struct hyper_exec *exec, struct hyper_pod *pod, int
 	/* TODO: merge container env to exec env in hyperd */
 	if (hyper_setup_env(c->exec.envs, c->exec.envs_num) < 0) {
 		fprintf(stderr, "setup container envs for exec failed\n");
-		goto out;
-	}
-
-	/* already in pidns & mntns of container, mount proc filesystem */
-	if (exec->init && mount("proc", "/proc", "proc", MS_NOSUID| MS_NODEV| MS_NOEXEC, NULL) < 0) {
-		perror("fail to mount proc filesystem for container");
 		goto out;
 	}
 

--- a/src/exec.h
+++ b/src/exec.h
@@ -45,18 +45,10 @@ struct hyper_exec {
 struct hyper_pod;
 
 int hyper_exec_cmd(char *json, int length);
-int hyper_release_exec(struct hyper_exec *, struct hyper_pod *);
-int hyper_container_execcmd(struct hyper_pod *pod);
-int hyper_setup_exec_tty(struct hyper_exec *e);
-int hyper_dup_exec_tty(struct hyper_exec *e);
 int hyper_run_process(struct hyper_exec *e);
-void hyper_exec_process(struct hyper_exec *e);
 struct hyper_exec *hyper_find_exec_by_pid(struct list_head *head, int pid);
 struct hyper_exec *hyper_find_exec_by_seq(struct hyper_pod *pod, uint64_t seq);
-int hyper_setup_exec_user(struct hyper_exec *e);
 int hyper_handle_exec_exit(struct hyper_pod *pod, int pid, uint8_t code);
-int hyper_watch_exec_pty(struct hyper_exec *exec, struct hyper_pod *pod);
 void hyper_cleanup_exec(struct hyper_pod *pod);
 
-extern struct hyper_event_ops pts_ops;
 #endif

--- a/src/hyper.h
+++ b/src/hyper.h
@@ -119,6 +119,7 @@ static inline int hyper_create(char *hyper_path)
 
 int hyper_open_serial(char *tty);
 void hyper_cleanup_pod(struct hyper_pod *pod);
+int hyper_enter_sandbox(struct hyper_pod *pod, int pidpipe);
 
 extern struct hyper_pod global_pod;
 extern struct hyper_ctl ctl;

--- a/src/hyper.h
+++ b/src/hyper.h
@@ -74,7 +74,6 @@ struct portmapping_white_list {
 };
 
 struct hyper_win_size {
-	char		*tty;
 	int		row;
 	int		column;
 	uint64_t	seq;

--- a/src/hyper.h
+++ b/src/hyper.h
@@ -119,7 +119,6 @@ static inline int hyper_create(char *hyper_path)
 }
 
 int hyper_open_serial(char *tty);
-int hyper_start_containers(struct hyper_pod *pod);
 void hyper_cleanup_pod(struct hyper_pod *pod);
 
 extern struct hyper_pod global_pod;

--- a/src/init.c
+++ b/src/init.c
@@ -275,7 +275,7 @@ fail:
 	goto out;
 }
 
-int hyper_start_containers(struct hyper_pod *pod)
+static int hyper_start_containers(struct hyper_pod *pod)
 {
 	struct hyper_container *c;
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -1292,28 +1292,24 @@ realloc:
 			continue;
 
 		if (i++ == n)
-			goto fail;
+			goto out;
 
-		if (json_token_streq(json, t, "tty")) {
-			if (toks[i].type != JSMN_STRING)
-				goto fail;
-			ws->tty = (json_token_str(json, &toks[i]));
-		} else if (json_token_streq(json, t, "seq")) {
+		if (json_token_streq(json, t, "seq")) {
 			if (toks[i].type != JSMN_PRIMITIVE)
-				goto fail;
+				goto out;
 			ws->seq = json_token_ll(json, &toks[i]);
 		} else if (json_token_streq(json, t, "row")) {
 			if (toks[i].type != JSMN_PRIMITIVE)
-				goto fail;
+				goto out;
 			ws->row = json_token_int(json, &toks[i]);
 		} else if (json_token_streq(json, t, "column")) {
 			if (toks[i].type != JSMN_PRIMITIVE)
-				goto fail;
+				goto out;
 			ws->column = json_token_int(json, &toks[i]);
 		} else {
 			fprintf(stderr, "get unknown section %s in winsize\n",
 				json_token_str(json, t));
-			goto fail;
+			goto out;
 		}
 	}
 
@@ -1321,10 +1317,6 @@ realloc:
 out:
 	free(toks);
 	return ret;
-fail:
-	free(ws->tty);
-	ws->tty = NULL;
-	goto out;
 }
 
 struct hyper_exec *hyper_parse_execcmd(char *json, int length)


### PR DESCRIPTION
introduce hyper_enter_sandbox()
and enter the sandbox when hyper_setup_container_rootfs()
so that we can mount the procfs in hyper_setup_container_rootfs()