### PR TITLE
fix up file volume binding handling

### DIFF
--- a/src/container.c
+++ b/src/container.c
@@ -144,6 +144,7 @@ static int container_setup_volume(struct hyper_container *container)
 				}
 			}
 		} else {
+			hyper_filize(mountpoint);
 			if (hyper_create_file(mountpoint) < 0) {
 				perror("create volume file failed");
 				return -1;

--- a/src/util.c
+++ b/src/util.c
@@ -208,6 +208,23 @@ int hyper_getgrouplist(const char *user, gid_t group, gid_t *groups, int *ngroup
 	return ret;
 }
 
+static int hyper_create_parent_dir(const char *hyper_path)
+{
+	char *p, *path = strdup(hyper_path);
+	int ret = 0;
+
+	if (path == NULL)
+		return -1;
+	p = strrchr(path, '/');
+	if (p != NULL && p != path) {
+		*p = '\0';
+		ret = hyper_mkdir(path, 0777);
+	}
+	free(path);
+
+	return ret;
+}
+
 int hyper_create_file(const char *hyper_path)
 {
 	int fd;
@@ -219,6 +236,9 @@ int hyper_create_file(const char *hyper_path)
 		errno = S_ISDIR(stbuf.st_mode) ? EISDIR : EINVAL;
 		return -1;
 	}
+
+	if (hyper_create_parent_dir(hyper_path) < 0)
+		return -1;
 
 	fd = open(hyper_path, O_CREAT|O_WRONLY, 0666);
 	if (fd < 0)

--- a/src/util.c
+++ b/src/util.c
@@ -208,6 +208,21 @@ int hyper_getgrouplist(const char *user, gid_t group, gid_t *groups, int *ngroup
 	return ret;
 }
 
+/* Trim all trailing '/' of a hyper_path except for the prefix one. */
+void hyper_filize(char *hyper_path)
+{
+	char *p;
+
+	if (strlen(hyper_path) == 0)
+		return;
+
+	p = &hyper_path[strlen(hyper_path) - 1];
+
+	for (; *p == '/' && p != hyper_path; p--) {
+		*p = '\0';
+	}
+}
+
 static int hyper_create_parent_dir(const char *hyper_path)
 {
 	char *p, *path = strdup(hyper_path);
@@ -225,6 +240,7 @@ static int hyper_create_parent_dir(const char *hyper_path)
 	return ret;
 }
 
+/* hyper_path must point to a file rather than a directory, e.g., having trailing '/' */
 int hyper_create_file(const char *hyper_path)
 {
 	int fd;

--- a/src/util.h
+++ b/src/util.h
@@ -26,6 +26,7 @@ void online_cpu(void);
 void online_memory(void);
 int hyper_cmd(char *cmd);
 int hyper_create_file(const char *hyper_path);
+void hyper_filize(char *hyper_path);
 int hyper_mkdir(char *path, mode_t mode);
 int hyper_open_channel(char *channel, int mode);
 int hyper_open_serial_dev(char *tty);


### PR DESCRIPTION
1. if a binding destination is a file inside some directory, create its parent directories.
2. if a file volume binding destination is a directory, force marking it as a file instead, following docker's practice.

```
[lear@local]$mypkt run -d -v d7d9fbf4b02fdf70c974e2c04e497a441ab70ada38b72c278946182c73daaf4:/vol/data0/ busybox
f37ac3cc4d05802e9ed18c9ed5aea07f44d545e7176f9213c1812ca4dbaed86d
[lear@local]$mypkt exec f37ac3cc4d05802e9ed18c9ed5aea07f44d545e7176f9213c1812ca4dbaed86d ls -l /vol/data0
-rw-r--r--    1 root     root          3027 Aug  8 10:40 /vol/data0
```
```
[lear@local]$mypkt run -d -v d7d9fbf4b02fdf70c974e2c04e497a441ab70ada38b72c278946182c73daaf4:/vol/data0 busybox
9dc87c95dfa7d51f500075d89a239574428a55b8937e905b1a45946b0f38597a
[lear@local]$mypkt exec 9dc87c95dfa7d51f500075d89a239574428a55b8937e905b1a45946b0f38597a ls -l /vol/data0
-rw-r--r--    1 root     root          3027 Aug  8 10:40 /vol/data0
```