### PR TITLE
do not create _data dir without checking first

### DIFF
--- a/src/container.c
+++ b/src/container.c
@@ -69,6 +69,10 @@ static int container_check_file_volume(char *hyper_path, const char **filename)
 		return -1;
 	} else if (num != 3) {
 		fprintf(stdout, "%s has %d files/dirs\n", hyper_path, num - 2);
+		for (i = 0; i < num; i++) {
+			free(list[i]);
+		}
+		free(list);
 		return 0;
 	}
 


### PR DESCRIPTION
container_populate_volume() checks _data existance to determine if it
should populate old data. We only need to create new _data with 0777
mode if there is no existing one. That includes two cases:
1. before populating old data in container_populate_volume()
2. mount an empty volume for the fist time

For file volume case, we need to chmod it instead, to make sure any user
is able to read/write the file.