### PR TITLE
set umask when setting up container rootfs

### DIFF
--- a/src/container.c
+++ b/src/container.c
@@ -512,6 +512,9 @@ static int hyper_setup_container_rootfs(void *data)
 		goto fail;
 	}
 
+	/* To create files/directories accessible for all users. */
+	umask(0);
+
 	if (hyper_rescan_scsi() < 0) {
 		fprintf(stdout, "rescan scsi failed\n");
 		goto fail;


### PR DESCRIPTION
We want the mounted volume to be readable and writable to all users.

Before patch:
```
[lear@daemon]$mypkt run -d -v vol2:/foo/bar busybox
95c5f5eef2ecee75c4498f3ee8a495307af44a07a9e9070dad9be1c9ffa1ad2c
[lear@daemon]$mypkt exec 95c5f5eef2ecee75c4498f3ee8a495307af44a07a9e9070dad9be1c9ffa1ad2c ls -l /foo
total 4
drwxr-xr-x    2 root     root          4096 Aug 31 16:47 bar
```
After patch:
```
[lear@daemon]$mypkt run -d -v vol3:/foo/bar busybox
d26e82b5c5e909537563c32d5dcf2e78a2ae8d952e5a2208e79e00eaec62d613
[lear@daemon]$mypkt exec d26e82b5c5e909537563c32d5dcf2e78a2ae8d952e5a2208e79e00eaec62d613 ls -l /foo
total 4
drwxrwxrwx    2 root     root          4096 Aug 31 16:57 bar
```