### PR TITLE
Use macro SHARED_DIR for /tmp/hyper/shared path

### DIFF
--- a/src/container.c
+++ b/src/container.c
@@ -183,7 +183,7 @@ static int container_setup_volume(struct hyper_container *container)
 		struct fsmap *map = &container->maps[i];
 		char mountpoint[512];
 
-		sprintf(path, "/tmp/hyper/shared/%s", map->source);
+		sprintf(path, "%s/%s", SHARED_DIR, map->source);
 		sprintf(mountpoint, "./%s", map->path);
 		fprintf(stdout, "mount %s to %s\n", path, mountpoint);
 
@@ -567,7 +567,7 @@ static int hyper_setup_container_rootfs(void *data)
 	} else {
 		char path[512];
 
-		sprintf(path, "/tmp/hyper/shared/%s/", container->image);
+		sprintf(path, "%s/%s/", SHARED_DIR, container->image);
 		fprintf(stdout, "src directory %s\n", path);
 
 		if (mount(path, root, NULL, MS_BIND, NULL) < 0) {

--- a/src/hyper.h
+++ b/src/hyper.h
@@ -15,6 +15,9 @@
 #include "container.h"
 #include "portmapping.h"
 
+/* Path to rootfs shared directory */
+#define SHARED_DIR "/tmp/hyper/shared"
+
 enum {
 	POLICY_NEVER,
 	POLICY_ALWAYS,

--- a/src/init.c
+++ b/src/init.c
@@ -425,8 +425,8 @@ static int hyper_setup_shared(struct hyper_pod *pod)
 		return 0;
 	}
 
-	if (hyper_mkdir("/tmp/hyper/shared", 0755) < 0) {
-		perror("fail to create /tmp/hyper/shared");
+	if (hyper_mkdir(SHARED_DIR, 0755) < 0) {
+		perror("fail to create " SHARED_DIR);
 		return -1;
 	}
 
@@ -440,7 +440,7 @@ static int hyper_setup_shared(struct hyper_pod *pod)
 	mntinf.fmode		= ~0U;
 	strcpy(mntinf.name, pod->share_tag);
 
-	if (mount(NULL, "/tmp/hyper/shared", "vboxsf",
+	if (mount(NULL, SHARED_DIR, "vboxsf",
 		  MS_NODEV, &mntinf) < 0) {
 		perror("fail to mount shared dir");
 		return -1;
@@ -456,12 +456,12 @@ static int hyper_setup_shared(struct hyper_pod *pod)
 		return 0;
 	}
 
-	if (hyper_mkdir("/tmp/hyper/shared", 0755) < 0) {
-		perror("fail to create /tmp/hyper/shared");
+	if (hyper_mkdir(SHARED_DIR, 0755) < 0) {
+		perror("fail to create " SHARED_DIR);
 		return -1;
 	}
 
-	if (mount(pod->share_tag, "/tmp/hyper/shared", "9p",
+	if (mount(pod->share_tag, SHARED_DIR, "9p",
 		  MS_MGC_VAL| MS_NODEV, "trans=virtio") < 0) {
 
 		perror("fail to mount shared dir");
@@ -911,14 +911,14 @@ static void hyper_cleanup_shared(struct hyper_pod *pod)
 
 	free(pod->share_tag);
 	pod->share_tag = NULL;
-	if (umount("/tmp/hyper/shared") < 0 &&
-	    umount2("/tmp/hyper/shared", MNT_DETACH)) {
+	if (umount(SHARED_DIR) < 0 &&
+	    umount2(SHARED_DIR, MNT_DETACH)) {
 		perror("fail to umount shared dir");
 		return;
 	}
 
-	if (rmdir("/tmp/hyper/shared") < 0)
-		perror("fail to delete /tmp/hyper/shared");
+	if (rmdir(SHARED_DIR) < 0)
+		perror("fail to delete " SHARED_DIR);
 
 	sync();
 }


### PR DESCRIPTION
Hi,

This patch creates SHARED_DIR to be used to refer to shared directory  /tmp/hyper/shared.
Carlos