### PR TITLE
Consume all the data in handle()

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -197,13 +197,11 @@ int hyper_event_read(struct hyper_event *he, int efd)
 		return 0;
 	}
 
-	/* get the whole data */
+	/* get and consume the whole data */
 	if (he->ops->handle(he, len) != 0)
 		return -1;
 
-	/* len: length of the already get new data */
-	buf->get -= len;
-	memmove(buf->data, buf->data + len, buf->get);
+	buf->get = 0;
 
 	return 0;
 }

--- a/src/event.c
+++ b/src/event.c
@@ -135,6 +135,7 @@ int hyper_event_read(struct hyper_event *he, int efd)
 	int offset = he->ops->len_offset;
 	int end = offset + 4;
 	int size;
+	int ret;
 
 	fprintf(stdout, "%s\n", __func__);
 
@@ -198,12 +199,10 @@ int hyper_event_read(struct hyper_event *he, int efd)
 	}
 
 	/* get and consume the whole data */
-	if (he->ops->handle(he, len) != 0)
-		return -1;
-
+	ret = he->ops->handle(he, len);
 	buf->get = 0;
 
-	return 0;
+	return ret == 0 ? 0 : -1;
 }
 
 int hyper_event_write(struct hyper_event *he, int efd)


### PR DESCRIPTION
handle() always used all the data, so we direct set the buf->get to zero after it.