### PR TITLE
Allow docker to work out of the box

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,17 +4,17 @@
 AC_PREREQ([2.69])
 AC_INIT([hyperstart], [0.7.0], [www.hyper.sh])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
+AM_PROG_AR
 AM_EXTRA_RECURSIVE_TARGETS([initrd cbfs kernel])
 AC_CONFIG_SRCDIR([src/init.c])
 AC_CONFIG_HEADERS([config.h])
 
-# Checks for programs.
-AC_PROG_CC
-AM_PROG_CC_C_O
-# Checks for libraries.
+# Allow building libraries
+AC_PROG_RANLIB
 
 # Checks for header files.
-AC_CHECK_HEADERS([arpa/inet.h fcntl.h limits.h stddef.h stdint.h stdlib.h string.h sys/mount.h sys/socket.h unistd.h],
+AC_CHECK_HEADERS([arpa/inet.h fcntl.h limits.h stddef.h stdint.h stdlib.h \
+				  string.h sys/mount.h sys/socket.h unistd.h],
 [headers_found=yes],
 [headers_found=no])
 
@@ -31,7 +31,9 @@ AC_TYPE_UINT8_T
 
 # Checks for library functions.
 AC_FUNC_FORK
-AC_CHECK_FUNCS([dup2 memmove memset mkdir setenv socket strchr strdup strrchr strtoul], [fail=0], [fail=1])
+AC_CHECK_FUNCS([dup2 memmove memset mkdir setenv socket strchr strdup strrchr \
+				strtoul], 
+				[fail=0], [fail=1])
 AC_CHECK_FUNCS([setns])
 
 if test "$fail" = "1" ; then
@@ -44,7 +46,8 @@ AC_ARG_WITH([aarch64],
             [],[with_aarch64=no])
 
 if test "x$with_aarch64" != "xno" ; then
-    AC_DEFINE_UNQUOTED([WITH_AARCH64], 1, [run hyperstart with 64-bit ARM architecture])
+    AC_DEFINE_UNQUOTED([WITH_AARCH64], 1, 
+    				   [run hyperstart with 64-bit ARM architecture])
 fi
 
 AM_CONDITIONAL([WITH_AARCH64], [test "x$with_aarch64" != "xno"])
@@ -63,6 +66,7 @@ AM_CONDITIONAL([WITH_VBOX], [test "x$with_vbox" != "xno"])
 AC_CONFIG_FILES([
   Makefile
   src/Makefile
+  src/cgroup/Makefile
   build/Makefile
 ])
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,3 +1,15 @@
+SUBDIRS=cgroup
+
 AM_CFLAGS = -Wall -Werror
 bin_PROGRAMS=init
-init_SOURCES=init.c jsmn.c net.c util.c parse.c parson.c container.c exec.c event.c portmapping.c
+init_SOURCES=init.c \
+			jsmn.c \
+			net.c \
+			util.c \
+			parse.c \
+			parson.c \
+			container.c \
+			exec.c \
+			event.c \
+			portmapping.c
+init_LDADD = cgroup/libcgroup.a

--- a/src/cgroup/Makefile.am
+++ b/src/cgroup/Makefile.am
@@ -1,0 +1,3 @@
+AM_CFLAGS = -Wall -Werror -D_GNU_SOURCE
+noinst_LIBRARIES = libcgroup.a
+libcgroup_a_SOURCES = api.c

--- a/src/cgroup/README.md
+++ b/src/cgroup/README.md
@@ -1,0 +1,4 @@
+# Vendored libcgroup-like endpoints
+
+Hyperstart needs a very limited subset of libcgroup functionality. To keep the
+build simple, this code is recreated here rather then being linked-in.

--- a/src/cgroup/api.c
+++ b/src/cgroup/api.c
@@ -1,0 +1,144 @@
+/*
+ * libcgroup api functions which hyperstart would like to depend on without
+ * pulling in all of hyperstart.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+
+#include "error.h"
+#include "iterators.h"
+
+const char const *cgroup_strerror_codes[] = {
+	"Cgroup is not compiled in",
+	"Cgroup is not mounted",
+	"Cgroup does not exist",
+	"Cgroup has not been created",
+	"Cgroup one of the needed subsystems is not mounted",
+	"Cgroup, request came in from non owner",
+	"Cgroup controllers are bound to different mount points",
+	"Cgroup, operation not allowed",
+	"Cgroup value set exceeds maximum",
+	"Cgroup controller already exists",
+	"Cgroup value already exists",
+	"Cgroup invalid operation",
+	"Cgroup, creation of controller failed",
+	"Cgroup operation failed",
+	"Cgroup not initialized",
+	"Cgroup, requested group parameter does not exist",
+	"Cgroup generic error",
+	"Cgroup values are not equal",
+	"Cgroup controllers are different",
+	"Cgroup parsing failed",
+	"Cgroup, rules file does not exist",
+	"Cgroup mounting failed",
+	"End of File or iterator",
+	"Failed to parse config file",
+	"Have multiple paths for the same namespace",
+	"Controller in namespace does not exist",
+	"Either mount or namespace keyword has to be specified in the configuration file",
+	"This kernel does not support this feature",
+	"Value setting does not succeed",
+	"Failed to remove a non-empty group",
+};
+
+/*
+ * The errno which happend the last time (have to be thread specific)
+ */
+//__thread int last_errno;
+int last_errno;	// Not thread specific because hyperstart is single-threaded.
+
+#define MAXLEN 256
+
+/* the value have to be thread specific */
+//static __thread char errtext[MAXLEN];
+static char errtext[MAXLEN];
+
+int cgroup_get_all_controller_next(void **handle, struct controller_data *info)
+{
+	FILE *proc_cgroup = (FILE *) *handle;
+	int err = 0;
+	int hierarchy, num_cgroups, enabled;
+	char subsys_name[FILENAME_MAX];
+
+	if (!proc_cgroup)
+		return ECGINVAL;
+
+	if (!info)
+		return ECGINVAL;
+
+	err = fscanf(proc_cgroup, "%s %d %d %d\n", subsys_name,
+			&hierarchy, &num_cgroups, &enabled);
+
+	if (err != 4)
+		return ECGEOF;
+
+	strncpy(info->name, subsys_name, FILENAME_MAX);
+	info->name[FILENAME_MAX-1] = '\0';
+	info->hierarchy = hierarchy;
+	info->num_cgroups = num_cgroups;
+	info->enabled = enabled;
+
+	return 0;
+}
+
+int cgroup_get_all_controller_begin(void **handle, struct controller_data *info)
+{
+	FILE *proc_cgroup = NULL;
+	char buf[FILENAME_MAX];
+	int ret;
+
+	if (!info)
+		return ECGINVAL;
+
+	proc_cgroup = fopen("/proc/cgroups", "re");
+	if (!proc_cgroup) {
+		last_errno = errno;
+		return ECGOTHER;
+	}
+
+	if (!fgets(buf, FILENAME_MAX, proc_cgroup)) {
+		last_errno = errno;
+		fclose(proc_cgroup);
+		*handle = NULL;
+		return ECGOTHER;
+	}
+	*handle = proc_cgroup;
+
+	ret = cgroup_get_all_controller_next(handle, info);
+	if (ret != 0) {
+		fclose(proc_cgroup);
+		*handle = NULL;
+	}
+	return ret;
+}
+
+int cgroup_get_all_controller_end(void **handle)
+{
+	FILE *proc_cgroup = (FILE *) *handle;
+
+	if (!proc_cgroup)
+		return ECGINVAL;
+
+	fclose(proc_cgroup);
+	*handle = NULL;
+
+	return 0;
+}
+
+const char *cgroup_strerror(int code)
+{
+	if (code == ECGOTHER)
+		return strerror_r(cgroup_get_last_errno(), errtext, MAXLEN);
+
+	return cgroup_strerror_codes[code % ECGROUPNOTCOMPILED];
+}
+
+/**
+ * Return last errno, which caused ECGOTHER error.
+ */
+int cgroup_get_last_errno(void)
+{
+    return last_errno;
+}

--- a/src/cgroup/cgroup.h
+++ b/src/cgroup/cgroup.h
@@ -1,0 +1,11 @@
+#ifndef _CGROUP_H
+#define _CGROUP_H
+
+#define _CGROUP_H_INSIDE
+
+#include "iterators.h"
+#include "error.h"
+
+#undef _CGROUP_H_INSIDE
+
+#endif /* _CGROUP_H */

--- a/src/cgroup/error.h
+++ b/src/cgroup/error.h
@@ -1,0 +1,88 @@
+#ifndef _LIBCGROUP_ERROR_H
+#define _LIBCGROUP_ERROR_H
+
+/**
+ * @defgroup group_errors 6. Error handling
+ * @{
+ *
+ * @name Error handling
+ * @{
+ * Unless states otherwise in documentation of a function, all functions
+ * return @c int, which is zero (0) when the function succeeds, and positive
+ * number if the function fails.
+ *
+ * The returned integer is one of the ECG* values described below. Value
+ * #ECGOTHER means that the error was caused by underlying OS and the real
+ * cause can be found by calling cgroup_get_last_errno().
+ */
+
+enum {
+	ECGROUPNOTCOMPILED = 50000,
+	ECGROUPNOTMOUNTED,
+	ECGROUPNOTEXIST,
+	ECGROUPNOTCREATED,
+	ECGROUPSUBSYSNOTMOUNTED,
+	ECGROUPNOTOWNER,
+	/** Controllers bound to different mount points */
+	ECGROUPMULTIMOUNTED,
+	/* This is the stock error. Default error. @todo really? */
+	ECGROUPNOTALLOWED,
+	ECGMAXVALUESEXCEEDED,
+	ECGCONTROLLEREXISTS,
+	ECGVALUEEXISTS,
+	ECGINVAL,
+	ECGCONTROLLERCREATEFAILED,
+	ECGFAIL,
+	ECGROUPNOTINITIALIZED,
+	ECGROUPVALUENOTEXIST,
+	/**
+	 * Represents error coming from other libraries like glibc. @c libcgroup
+	 * users need to check cgroup_get_last_errno() upon encountering this
+	 * error.
+	 */
+	ECGOTHER,
+	ECGROUPNOTEQUAL,
+	ECGCONTROLLERNOTEQUAL,
+	/** Failed to parse rules configuration file. */
+	ECGROUPPARSEFAIL,
+	/** Rules list does not exist. */
+	ECGROUPNORULES,
+	ECGMOUNTFAIL,
+	/**
+	 * Not an real error, it just indicates that iterator has come to end
+	 * of sequence and no more items are left.
+	 */
+	ECGEOF = 50023,
+	/** Failed to parse config file (cgconfig.conf). */
+	ECGCONFIGPARSEFAIL,
+	ECGNAMESPACEPATHS,
+	ECGNAMESPACECONTROLLER,
+	ECGMOUNTNAMESPACE,
+	ECGROUPUNSUPP,
+	ECGCANTSETVALUE,
+	/** Removing of a group failed because it was not empty. */
+	ECGNONEMPTY,
+};
+
+/**
+ * Legacy definition of ECGRULESPARSEFAIL error code.
+ */
+#define ECGRULESPARSEFAIL	ECGROUPPARSEFAIL
+
+/**
+ * Format error code to a human-readable English string. No internationalization
+ * is currently done. Returned pointer leads to @c libcgroup memory and
+ * must not be freed nor modified. The memory is rewritten by subsequent
+ * call to this function.
+ * @param code Error code for which the corresponding error string is
+ * returned. When #ECGOTHER is used, text with glibc's description of
+ * cgroup_get_last_errno() value is returned.
+ */
+const char *cgroup_strerror(int code);
+
+/**
+ * Return last errno, which caused ECGOTHER error.
+ */
+int cgroup_get_last_errno(void);
+
+#endif /* _LIBCGROUP_INIT_H */

--- a/src/cgroup/iterators.h
+++ b/src/cgroup/iterators.h
@@ -1,0 +1,43 @@
+#ifndef _ITERATORS_H
+#define _ITERATORS_H
+
+#include <stdio.h>
+
+/**
+ * Detailed information about available controller.
+ */
+struct controller_data {
+	/** Controller name. */
+	char name[FILENAME_MAX];
+	/**
+	 * Hierarchy ID. Controllers with the same hierarchy ID
+	 * are mounted together as one hierarchy. Controllers with
+	 * ID 0 are not currently mounted anywhere.
+	 */
+	int hierarchy;
+	/** Number of groups. */
+	int num_cgroups;
+	/** Enabled flag. */
+	int enabled;
+};
+
+/**
+ * Read the first of controllers from /proc/cgroups.
+ * @param handle Handle to be used for iteration.
+ * @param info The structure which will be filled with controller data.
+ */
+int cgroup_get_all_controller_begin(void **handle,
+	struct controller_data *info);
+/**
+ * Read next controllers from /proc/cgroups.
+ * @param handle Handle to be used for iteration.
+ * @param info The structure which will be filled with controller data.
+ */
+int cgroup_get_all_controller_next(void **handle, struct controller_data *info);
+
+/**
+ * Release the iterator
+ */
+int cgroup_get_all_controller_end(void **handle);
+
+#endif /* _ITERATORS_H */

--- a/src/init.c
+++ b/src/init.c
@@ -459,7 +459,7 @@ static int hyper_setup_shared(struct hyper_pod *pod)
 	}
 
 	if (mount(pod->share_tag, SHARED_DIR, "9p",
-		  MS_MGC_VAL| MS_NODEV, "trans=virtio") < 0) {
+		  MS_MGC_VAL| MS_NODEV, "trans=virtio,cache=mmap") < 0) {
 
 		perror("fail to mount shared dir");
 		return -1;


### PR DESCRIPTION
These 3 patches add the options and functionality needed for docker to work "out of the box" in hyperstart.

The biggest required change is mounting the VMs cgroup controllers to running containers. The cgroup filesystem is mounted in read-write mode, as unlike in docker there is no need to isolate the host. This could be modified to behave more "docker-like" by picking up the "--privileged" flag and mounting them read-only if it conflicts with the other uses of hyper.

Note: there doesn't seem to be an equivalent `mmap` option for `vboxsf`, so docker _specifically_ will only work under xen/kvm.

Closes #80 
Closes https://github.com/hyperhq/runv/issues/319
