### PR TITLE
shutdown vm immediately if no container remained

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -527,7 +527,7 @@ void hyper_pod_destroyed(int failed)
 
 static int hyper_destroy_pod(struct hyper_pod *pod, int error)
 {
-	if (pod->init_pid == 0) {
+	if (pod->init_pid == 0 || pod->remains == 0) {
 		/* Pod stopped, just shutdown */
 		hyper_pod_destroyed(error);
 	} else {
@@ -589,11 +589,13 @@ static int hyper_new_container(char *json, int length)
 	ret = hyper_setup_container(c, pod);
 	if (ret >= 0)
 		ret = hyper_run_process(&c->exec);
+
 	if (ret < 0) {
 		//TODO full grace cleanup
 		hyper_cleanup_container(c, pod);
+	} else {
+		pod->remains++;
 	}
-	pod->remains++;
 
 	return ret;
 }


### PR DESCRIPTION
Hyperstart may receive destroy-event after all of the
containers are exited, then hyper_destroy_pod will still
try to term all processes, but there are no container will
exit and trigger the sending out podfinished-event/ack-event
logic in hyper_release_exec.

Add exec to global list only after process is running,
And add remains after container is running.

Signed-off-by: Gao feng <omarapazanadi@gmail.com>