### PR TITLE
Use binaries from PATH

### DIFF
--- a/build/make-initrd.sh
+++ b/build/make-initrd.sh
@@ -1,13 +1,35 @@
 #!/bin/bash
 
 rm -rf /tmp/hyperstart-rootfs
-mkdir -p /tmp/hyperstart-rootfs/lib /tmp/hyperstart-rootfs/lib64 /tmp/hyperstart-rootfs/lib/modules
+mkdir -p /tmp/hyperstart-rootfs/lib \
+	  /tmp/hyperstart-rootfs/lib64 \
+	  /tmp/hyperstart-rootfs/lib/modules
+
+mkdir -m 0755 -p /tmp/hyperstart-rootfs/dev \
+	  /tmp/hyperstart-rootfs/sys \
+	  /tmp/hyperstart-rootfs/sbin \
+	  /tmp/hyperstart-rootfs/bin \
+	  /tmp/hyperstart-rootfs/proc
 
 cp ../src/init /tmp/hyperstart-rootfs
 cp busybox /tmp/hyperstart-rootfs
 cp iptables /tmp/hyperstart-rootfs
 cp libm.so.6 /tmp/hyperstart-rootfs/lib64/
 tar -xf modules.tar -C /tmp/hyperstart-rootfs/lib/modules
+
+# create symlinks to busybox and iptables
+BUSYBOX_BINARIES=(/bin/sh /bin/tar /bin/hwclock /sbin/modprobe /sbin/depmod)
+for bin in ${BUSYBOX_BINARIES[@]}
+do
+	mkdir -p /tmp/hyperstart-rootfs/`dirname ${bin}`
+	ln -sf /busybox /tmp/hyperstart-rootfs/${bin}
+done
+IPTABLES_BINARIES=(/sbin/iptables /sbin/iptables-restore /sbin/iptables-save)
+for bin in ${IPTABLES_BINARIES[@]}
+do
+	mkdir -p /tmp/hyperstart-rootfs/`dirname ${bin}`
+	ln -sf /iptables /tmp/hyperstart-rootfs/${bin}
+done
 
 ldd /tmp/hyperstart-rootfs/init | while read line
 do

--- a/src/init.c
+++ b/src/init.c
@@ -1335,14 +1335,6 @@ int main(int argc, char *argv[])
 {
 	char *cmdline, *ctl_serial, *tty_serial;
 
-	if (hyper_mkdir("/dev", 0755) < 0 ||
-	    hyper_mkdir("/sys", 0755) < 0 ||
-	    hyper_mkdir("/sbin", 0755) < 0 ||
-	    hyper_mkdir("/proc", 0755) < 0) {
-		perror("create basic directory failed");
-		return -1;
-	}
-
 	if (mount("proc", "/proc", "proc", MS_NOSUID| MS_NODEV| MS_NOEXEC, NULL) == -1) {
 		perror("mount proc failed");
 		return -1;
@@ -1368,21 +1360,6 @@ int main(int argc, char *argv[])
 	if (mount("devpts", "/dev/pts", "devpts", MS_NOSUID| MS_NOEXEC, NULL) == -1) {
 		perror("mount devpts failed");
 		return -1;
-	}
-
-	if (symlink("/busybox", "/sh") < 0 ||
-	    symlink("/busybox", "/tar") < 0 ||
-	    symlink("/busybox", "/sbin/modprobe") < 0 ||
-	    symlink("/busybox", "/sbin/depmod") < 0) {
-		perror("failed to symlink tools to /busybox");
-		return -1;
-	}
-
-	if (symlink("/iptables", "/sbin/iptables") < 0 ||
-	    symlink("/iptables", "/sbin/iptables-restore") < 0 ||
-	    symlink("/iptables", "/sbin/iptables-save") < 0) {
-		perror("failed to symlink tools to /iptables");
-		/* TODO disable portmapping */
 	}
 
 	cmdline = read_cmdline();

--- a/src/portmapping.c
+++ b/src/portmapping.c
@@ -16,7 +16,7 @@
 
 int hyper_init_modules() 
 {
-	int status = hyper_cmd("/sbin/depmod");
+	int status = hyper_cmd("depmod");
 	if (status != 0) {
 		fprintf(stderr, "depmod failed, status: %d\n", status);
 		return -1;
@@ -32,10 +32,10 @@ int hyper_setup_iptables_rule(struct ipt_rule rule)
 	int check = -1;
 
 	if (rule.rule != NULL) {
-		sprintf(check_cmd, "/sbin/iptables -t %s -C %s %s", rule.table, rule.chain, rule.rule);
-		sprintf(cmd, "/sbin/iptables -t %s %s %s %s", rule.table, rule.op, rule.chain, rule.rule);
+		sprintf(check_cmd, "iptables -t %s -C %s %s", rule.table, rule.chain, rule.rule);
+		sprintf(cmd, "iptables -t %s %s %s %s", rule.table, rule.op, rule.chain, rule.rule);
 	} else {
-		sprintf(cmd, "/sbin/iptables -t %s %s %s", rule.table, rule.op, rule.chain);
+		sprintf(cmd, "iptables -t %s %s %s", rule.table, rule.op, rule.chain);
 	}
 
 	if (strlen(check_cmd) > 0) {

--- a/src/util.c
+++ b/src/util.c
@@ -71,7 +71,7 @@ int hyper_list_dir(char *path)
 int hyper_copy_dir(char *src, char *dest)
 {
 	char cmd[512];
-	snprintf(cmd, sizeof(cmd), "/tar cf - -C %s . | /tar fx - -C %s", src, dest);
+	snprintf(cmd, sizeof(cmd), "tar cf - -C %s . | tar fx - -C %s", src, dest);
 
 	return hyper_cmd(cmd);
 }
@@ -82,7 +82,7 @@ void hyper_sync_time_hctosys() {
 	if (pid < 0) {
 		perror("fail to fork to copy directory");
 	} else if (pid == 0) {
-		execlp("/busybox", "hwclock", "-s", NULL);
+		execlp("hwclock", "hwclock", "-s", NULL);
 		perror("exec hwclock -s command failed");
 		exit(-1);
 	}
@@ -703,7 +703,7 @@ int hyper_cmd(char *cmd)
 		return -1;
 	} else {
 		fprintf(stdout, "executing cmd %s\n", cmd);
-		execlp("/busybox", "sh", "-c", cmd, NULL);
+		execlp("sh", "sh", "-c", cmd, NULL);
 	}
 
 	return -1;


### PR DESCRIPTION
With this patch binaries dependencies are added
to configure.ac therefore binaries path are resolved
at configuration time removing busybox binary dependency
making hyperstart more compatible and easier to
integrate with different OS's

Signed-off-by: Julio Montes <julio.montes@intel.com>