### PR TITLE
hyperstart should not end when rescan scsi fails

### DIFF
--- a/src/container.c
+++ b/src/container.c
@@ -529,7 +529,7 @@ static int hyper_setup_container_rootfs(void *data)
 	/* To create files/directories accessible for all users. */
 	umask(0);
 
-	if (hyper_rescan_scsi() < 0) {
+	if (container->fstype && hyper_rescan_scsi() < 0) {
 		fprintf(stdout, "rescan scsi failed\n");
 		goto fail;
 	}


### PR DESCRIPTION
With this patch an error will be reported when re-scan
scsi fails, allowing hyperstart continue with its work

Signed-off-by: Julio Montes <julio.montes@intel.com>