### PR TITLE
move hyper_kill_container_processes() up

### DIFF
--- a/src/exec.c
+++ b/src/exec.c
@@ -829,10 +829,10 @@ int hyper_handle_exec_exit(struct hyper_pod *pod, int pid, uint8_t code)
 	close(exec->ptyfd);
 	exec->ptyfd = -1;
 
-	hyper_release_exec(exec);
-
 	if (exec->init)
 		hyper_kill_container_processes(container_of(exec, struct hyper_container, exec));
+
+	hyper_release_exec(exec);
 
 	return 0;
 }


### PR DESCRIPTION
hyper_kill_container_processes() depends on container->ns,
but hyper_release_exec() may calls hyper_cleanup_pod() which
calls hyper_cleanup_containers() and then hyper_cleanup_container(),
and container->ns is closed in hyper_cleanup_container().
It cause hyper_kill_container_processes() failed to
stat the container->ns.

[root@box ~]# grep 'fail to stat mnt ns' /var/log/hyper/ -rIn -l
/var/log/hyper/hyperd.sbox.root.log.INFO.20160923-231500.17245
/var/log/hyper/hyperd.sbox.root.log.INFO.20160925-100719.3091
/var/log/hyper/hyperd.sbox.root.log.INFO.20160925-104216.3720
/var/log/hyper/hyperd.sbox.root.log.INFO.20160925-195450.8766
/var/log/hyper/hyperd.sbox.root.log.INFO.20160926-150357.7493
/var/log/hyper/hyperd.sbox.root.log.INFO.20160926-151213.10722
/var/log/hyper/hyperd.sbox.root.log.INFO.20160926-151555.13867
/var/log/hyper/hyperd.sbox.root.log.INFO.20160926-152510.22823
/var/log/hyper/hyperd.sbox.root.log.INFO.20160926-171120.2454
/var/log/hyper/hyperd.sbox.root.log.INFO.20160926-174512.3308
/var/log/hyper/hyperd.sbox.root.log.INFO.20160928-153012.27740
/var/log/hyper/hyperd.sbox.root.log.INFO.20160929-214026.17673
/var/log/hyper/hyperd.sbox.root.log.INFO.20160929-222011.18735
/var/log/hyper/hyperd.sbox.root.log.INFO.20161001-004225.5899
[root@box ~]# grep 'fail to stat mnt ns' /var/log/hyper/ -rIn -l | wc
     14      14     875

it can be triggered via 'hyperctl run -t ubuntu' and then 'exit'
in the shell of the container.

so we have to swap the order of hyper_kill_container_processes
and hyper_release_exec().

Signed-off-by: Lai Jiangshan <jiangshanlai@gmail.com>