### PR TITLE
do not call any functions before check errno

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -1244,14 +1244,14 @@ static int hyper_loop(void)
 
 	while (1) {
 		n = epoll_pwait(ctl.efd, events, MAXEVENTS, -1, &omask);
-		fprintf(stdout, "%s epoll_wait %d\n", __func__, n);
-
 		if (n < 0) {
 			if (errno == EINTR)
 				continue;
 			perror("hyper wait event failed");
 			return -1;
 		}
+		fprintf(stdout, "%s epoll_wait %d\n", __func__, n);
+
 		for (i = 0; i < n; i++) {
 			if (hyper_handle_event(ctl.efd, &events[i]) < 0)
 				return -1;

--- a/src/net.c
+++ b/src/net.c
@@ -48,7 +48,6 @@ int hyper_send_data(int fd, uint8_t *data, uint32_t len)
 
 	while (length < len) {
 		size = write(fd, data + length, len - length);
-
 		if (size <= 0) {
 			if (errno == EINTR)
 				continue;
@@ -99,7 +98,6 @@ int hyper_get_type(int fd, uint32_t *type)
 
 	while (len < 8) {
 		size = read(fd, buf + len, 8 - len);
-
 		if (size <= 0) {
 			if (errno == EINTR)
 				continue;

--- a/src/util.c
+++ b/src/util.c
@@ -415,13 +415,12 @@ int hyper_open_channel(char *channel, int mode)
 {
 	struct termios term;
 	int fd = open(channel, O_RDWR | O_CLOEXEC | mode);
-	fprintf(stdout, "open %s get %d\n", channel, fd);
-
 	if (fd < 0) {
 		perror("fail to open channel device");
 		return -1;
 	}
 
+	fprintf(stdout, "open %s get %d\n", channel, fd);
 	bzero(&term, sizeof(term));
 
 	cfmakeraw(&term);


### PR DESCRIPTION
perror changes the errno, result in the errno checking
of execvp incorrect.

Signed-off-by: Gao feng <omarapazanadi@gmail.com>