### PR TITLE
Add support for multiple ip addresses for a network interface

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -10,6 +10,8 @@
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
 
+#include "list.h"
+
 struct rtnl_handle {
 	int fd;
 	struct sockaddr_nl local;
@@ -18,11 +20,16 @@ struct rtnl_handle {
 	__u32 dump;
 };
 
+struct hyper_ipaddress {
+	struct list_head list;
+	char *addr;
+	char *mask;
+};
+
 struct hyper_interface {
-	char		*device;
-	char		*ipaddr;
-	char		*mask;
-	char            *new_device_name;
+	char		 *device;
+	struct list_head  ipaddresses;
+	char             *new_device_name;
 };
 
 struct hyper_route {

--- a/src/parse.h
+++ b/src/parse.h
@@ -14,6 +14,7 @@ int hyper_parse_file_command(struct file_command *cmd, char *json, int length);
 struct hyper_container *hyper_parse_new_container(struct hyper_pod *pod, char *json, int length);
 void hyper_free_container(struct hyper_container *c);
 struct hyper_interface *hyper_parse_setup_interface(char *json, int length);
+void hyper_free_interface(struct hyper_interface *iface);
 int hyper_parse_setup_routes(struct hyper_route **routes, uint32_t *r_num, char *json, int length);
 JSON_Value *hyper_json_parse(char *json, int length);
 


### PR DESCRIPTION
A network interface can have multiple IP addresses. Change the interface json
to accept a list of IP addresses instead of a single value.

Signed-off-by: Archana Shinde archana.m.shinde@intel.com
