### PR TITLE
"Daemon" mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ tags
 /src/hyperstart
 build/hyper_daemon
 build/hyper-initrd.img
+data/hyperstart.service
 build/cbfs.rom
 build/root/*
 build/*iso

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 .deps
 TAGS
 tags
-init
+/src/hyperstart
 build/hyper_daemon
 build/hyper-initrd.img
 build/cbfs.rom

--- a/.gitignore
+++ b/.gitignore
@@ -28,10 +28,7 @@ cscope.po.out
 stamp-h
 stamp-h.in
 stamp-h1
-/config.h
-/config.h.in
-/config.log
-/config.status
+/config.*
 /configure
 /aclocal.m4
 /autoscan.log

--- a/Makefile.am
+++ b/Makefile.am
@@ -6,3 +6,8 @@ cbfs-local:
 	@echo finish make cbfs
 kernel-local:
 	@echo finish make kernel
+
+if SYSTEMD
+SYSTEMD_SYS_UNITdir = @SYSTEMD_SYSTEMUNIT@
+SYSTEMD_SYS_UNIT_DATA = data/hyperstart.service
+endif

--- a/build/make-initrd.sh
+++ b/build/make-initrd.sh
@@ -11,7 +11,7 @@ mkdir -m 0755 -p /tmp/hyperstart-rootfs/dev \
 	  /tmp/hyperstart-rootfs/bin \
 	  /tmp/hyperstart-rootfs/proc
 
-cp ../src/init /tmp/hyperstart-rootfs/
+cp ../src/hyperstart /tmp/hyperstart-rootfs/init
 cp busybox /tmp/hyperstart-rootfs/sbin/
 cp iptables /tmp/hyperstart-rootfs/sbin/
 cp ipvsadm /tmp/hyperstart-rootfs/sbin/

--- a/configure.ac
+++ b/configure.ac
@@ -11,6 +11,8 @@ AC_CONFIG_HEADERS([config.h])
 # Checks for programs.
 AC_PROG_CC
 AM_PROG_CC_C_O
+AC_CHECK_PROG(PKG_CONFIG, [pkg-config], [pkg-config], [:])
+
 # Checks for libraries.
 
 # Checks for header files.
@@ -60,10 +62,22 @@ fi
 
 AM_CONDITIONAL([WITH_VBOX], [test "x$with_vbox" != "xno"])
 
+AC_ARG_WITH([systemdsystemunitdir],
+            AS_HELP_STRING([--with-systemdsystemunitdir=SYSTEMD_SYSTEM_UNIT_DIR],
+                           [path to install systemd system service]),
+                           [SYSTEMD_SYSTEMUNIT=${withval}],
+                           [SYSTEMD_SYSTEMUNIT="`$PKG_CONFIG --variable=systemdsystemunitdir systemd 2>/dev/null`"])
+
+AS_IF([test -z "$SYSTEMD_SYSTEMUNIT"],[SYSTEMD_SYSTEMUNIT=no])
+AS_IF([test "x$enable_daemon" = "xno"],[SYSTEMD_SYSTEMUNIT=no])
+AC_SUBST(SYSTEMD_SYSTEMUNIT)
+AM_CONDITIONAL(SYSTEMD, test "x${SYSTEMD_SYSTEMUNIT}" != "xno" )
+
 AC_CONFIG_FILES([
   Makefile
   src/Makefile
   build/Makefile
+  data/hyperstart.service
 ])
 AC_OUTPUT
 
@@ -79,4 +93,5 @@ AC_MSG_RESULT([
 	suid cflags:       ${SUID_CFLAGS}
 	ldflags:           ${LDFLAGS}
 	suid ldflags:      ${SUID_LDFLAGS}
+	systemd unit path: ${SYSTEMD_SYSTEMUNIT}
 ])

--- a/data/hyperstart.service.in
+++ b/data/hyperstart.service.in
@@ -1,0 +1,5 @@
+[Unit]
+Description=hyperstart guest daemon
+
+[Service]
+ExecStart=@prefix@/bin/hyperstart

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,3 +1,3 @@
 AM_CFLAGS = -Wall -Werror
-bin_PROGRAMS=init
-init_SOURCES=init.c jsmn.c net.c util.c parse.c parson.c container.c exec.c event.c portmapping.c
+bin_PROGRAMS=hyperstart
+hyperstart_SOURCES=init.c jsmn.c net.c util.c parse.c parson.c container.c exec.c event.c portmapping.c

--- a/src/init.c
+++ b/src/init.c
@@ -1341,10 +1341,9 @@ static int hyper_loop(void)
 	return 0;
 }
 
-int main(int argc, char *argv[])
+static int hyper_setup_init_process(void)
 {
-	char *cmdline, *ctl_serial, *tty_serial;
-
+	/* mount the base file systems */
 	if (mount("proc", "/proc", "proc", MS_NOSUID| MS_NODEV| MS_NOEXEC, NULL) == -1) {
 		perror("mount proc failed");
 		return -1;
@@ -1381,11 +1380,26 @@ int main(int argc, char *argv[])
 		return -1;
 	}
 
-	cmdline = read_cmdline();
-
+	/* become the session leader */
 	setsid();
 
+	/* set the controlling terminal */
 	ioctl(STDIN_FILENO, TIOCSCTTY, 1);
+
+	setenv("PATH", "/bin:/sbin/:/usr/bin/:/usr/sbin/", 1);
+
+	return 0;
+}
+
+int main(int argc, char *argv[])
+{
+	char *cmdline, *ctl_serial, *tty_serial;
+
+	if (hyper_setup_init_process() < 0) {
+		return -1;
+	}
+
+	cmdline = read_cmdline();
 
 #ifdef WITH_VBOX
 	ctl_serial = "/dev/ttyS0";
@@ -1400,8 +1414,6 @@ int main(int argc, char *argv[])
 	ctl_serial = "sh.hyper.channel.0";
 	tty_serial = "sh.hyper.channel.1";
 #endif
-
-	setenv("PATH", "/bin:/sbin/:/usr/bin/:/usr/sbin/", 1);
 
 	hyper_epoll.ctl.fd = hyper_setup_ctl_channel(ctl_serial);
 	if (hyper_epoll.ctl.fd < 0) {

--- a/src/init.c
+++ b/src/init.c
@@ -1,4 +1,5 @@
 #define _GNU_SOURCE
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -1393,9 +1394,13 @@ static int hyper_setup_init_process(void)
 
 int main(int argc, char *argv[])
 {
-	char *cmdline, *ctl_serial, *tty_serial;
+	char *binary_name, *cmdline, *ctl_serial, *tty_serial;
+	bool is_init;
 
-	if (hyper_setup_init_process() < 0) {
+	binary_name = basename(argv[0]);
+	is_init = strncmp(binary_name, "init", 5) == 0;
+
+	if (is_init && hyper_setup_init_process() < 0) {
 		return -1;
 	}
 


### PR DESCRIPTION
It'd be nice if we could use hyperstart as a regular daemon instead of just an init system. This allows us to:
- Customise the OS we run inside the VM. There are configurations where we want a fuller OS than just an initrd+hyperstart. In those cases, hyperstart becomes a daemon started by systemd.
- Something else that could be nice is to have hyperstart started by nsenter or systemd-nspawn so we can debug it on the host side (gdb, strace, ...). I have something like this sort of working and this series is the start of it.
