### PR TITLE
exec: enter container workdir

### DIFF
--- a/src/exec.c
+++ b/src/exec.c
@@ -492,12 +492,6 @@ static int hyper_do_exec_cmd(struct hyper_exec *exec, int pipe, struct stdio_con
 		goto out;
 	}
 
-	/* TODO: merge container env to exec env in hyperd */
-	if (hyper_setup_env(c->exec.envs, c->exec.envs_num) < 0) {
-		fprintf(stderr, "setup container envs for exec failed\n");
-		goto out;
-	}
-
 	// set early env. the container env config can overwrite it
 	setenv("HOME", "/root", 1);
 	setenv("HOSTNAME", exec->pod->hostname, 1);
@@ -506,6 +500,18 @@ static int hyper_do_exec_cmd(struct hyper_exec *exec, int pipe, struct stdio_con
 	else
 		unsetenv("TERM");
 
+	if (exec->init == 0) {
+		/* TODO: merge container env to exec env in hyperd */
+		if (hyper_setup_env(c->exec.envs, c->exec.envs_num) < 0) {
+			fprintf(stderr, "setup container envs for exec failed\n");
+			goto out;
+		}
+		/* TODO: copy container workdir to exec workdir in hyperd */
+		if (c->exec.workdir && chdir(c->exec.workdir) < 0) {
+			perror("enter container workdir failed\n");
+			goto out;
+		}
+	}
 	hyper_exec_process(exec, io);
 
 out:


### PR DESCRIPTION
make the behavior consists with docker.
and fix the bug that overwrite container env.

TODO: combine env and workdir of exec in hyperd
after finish the refactor of hyperd/runv.

Signed-off-by: Gao feng <omarapazanadi@gmail.com>