### PR TITLE
add hyperstart-exec

### DIFF
--- a/src/api.h
+++ b/src/api.h
@@ -32,6 +32,13 @@ enum {
 	PROCESSASYNCEVENT,
 };
 
+// "hyperstart" is the special container ID for adding processes.
+//
+// The processes will be execve()-ed in the same namespaces as the
+// hyperstart(init) process rather than in any container.
+// This operation is "hyperstart-exec"
+#define HYPERSTART_EXEC_CONTAINER "hyperstart"
+
 /*
  * control message format
  * | ctrl id | length  | payload (length-8)      |

--- a/src/container.h
+++ b/src/container.h
@@ -2,6 +2,7 @@
 #define _CONTAINER_H_
 
 #include "exec.h"
+#include "api.h"
 
 struct volume {
 	char	*device;
@@ -61,4 +62,7 @@ void hyper_cleanup_container(struct hyper_container *container, struct hyper_pod
 void hyper_cleanup_containers(struct hyper_pod *pod);
 void hyper_free_container(struct hyper_container *c);
 
+static inline int hyper_has_container(struct hyper_pod *pod, const char *id) {
+	return strcmp(id, HYPERSTART_EXEC_CONTAINER) == 0 || hyper_find_container(pod, id) != NULL;
+}
 #endif

--- a/src/exec.c
+++ b/src/exec.c
@@ -599,7 +599,7 @@ int hyper_exec_cmd(struct hyper_pod *pod, char *json, int length)
 		return -1;
 	}
 
-	if (hyper_find_container(pod, exec->container_id) == NULL) {
+	if (!hyper_has_container(pod, exec->container_id)) {
 		fprintf(stderr, "call hyper_exec_cmd, no such container: %s\n", exec->container_id);
 		hyper_free_exec(exec);
 		return -1;
@@ -646,6 +646,11 @@ int hyper_run_process(struct hyper_exec *exec)
 		perror("fork prerequisite process failed");
 		goto close_tty;
 	} else if (pid == 0) {
+		if (strcmp(exec->container_id, HYPERSTART_EXEC_CONTAINER) == 0) {
+			hyper_send_type(pipe[1], getpid());
+			hyper_exec_process(exec, &io);
+			_exit(125);
+		}
 		hyper_do_exec_cmd(exec, pipe[1], &io);
 	}
 	fprintf(stdout, "prerequisite process pid %d\n", pid);


### PR DESCRIPTION
The target process is directly execve()-ed by the hyperstart
process in the namespaces of the hyperstart rather than in
any container.

So that we can use this special api for misc operations
rather than add new hyperstart commands.

We may use this hyperstart-exec operation to replace the existed
some misc-style hyperstart commands in the future.

Signed-off-by: Lai Jiangshan <jiangshanlai@gmail.com>