### PR TITLE
setup cloexec flag for stdioevfd in tty case

### DIFF
--- a/src/exec.c
+++ b/src/exec.c
@@ -444,9 +444,12 @@ static int hyper_setup_stdio_events(struct hyper_exec *exec, struct stdio_config
 {
 	if (exec->tty) {
 		io->stdinevfd = dup(exec->ptyfd);
+		hyper_setfd_cloexec(io->stdinevfd);
 		io->stdoutevfd = dup(exec->ptyfd);
+		hyper_setfd_cloexec(io->stdoutevfd);
 		if (exec->errseq == 0) {
 			io->stderrevfd = dup(exec->ptyfd);
+			hyper_setfd_cloexec(io->stderrevfd);
 		}
 	}
 


### PR DESCRIPTION
otherwise these fds will be seen by other execs and new containers

Signed-off-by: Gao feng <omarapazanadi@gmail.com>