### PR TITLE
Clear the environment before setting container environment.

### DIFF
--- a/src/exec.c
+++ b/src/exec.c
@@ -510,6 +510,9 @@ static int hyper_do_exec_cmd(struct hyper_exec *exec, int pipe, struct stdio_con
 		goto out;
 	}
 
+	// Make sure we start with a clean environment
+	clearenv();
+
 	// set early env. the container env config can overwrite it
 	setenv("HOME", "/root", 1);
 	setenv("HOSTNAME", exec->pod->hostname, 1);


### PR DESCRIPTION
This ensures that there are no erroneous env variables left over by
any subsystem before the container and process specific env
variables are applied.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>