### PR TITLE
Set errno to zero for checking it after strtol().

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -126,6 +126,7 @@ int hyper_find_sd(char *addr, char **dev)
 static unsigned long id_or_max(const char *name)
 {
 	char *ptr;
+	errno = 0;
 	long id = strtol(name, &ptr, 10);
 	if (name == ptr || id < 0 || (errno != 0 && id == 0) || *ptr != '\0')
 		return ~0UL;


### PR DESCRIPTION
It is necessary to clear the errno out first before calling strtol.
This was causing issues when uid/gid was passed as 0.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>