### PR TITLE
Handle additional groups that may not exist in the container.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,7 +14,7 @@ AM_PROG_CC_C_O
 # Checks for libraries.
 
 # Checks for header files.
-AC_CHECK_HEADERS([arpa/inet.h fcntl.h limits.h stddef.h stdint.h stdlib.h string.h sys/mount.h sys/socket.h unistd.h],
+AC_CHECK_HEADERS([arpa/inet.h fcntl.h limits.h stddef.h stdint.h stdlib.h string.h sys/mount.h sys/socket.h unistd.h stdbool.h],
 [headers_found=yes],
 [headers_found=no])
 

--- a/src/exec.c
+++ b/src/exec.c
@@ -267,13 +267,18 @@ static int hyper_setup_exec_user(struct hyper_exec *exec)
 		goto fail;
 	groups = reallocgroups;
 	for (i = 0; i < exec->nr_additional_groups; i++) {
+		unsigned long id;
 		fprintf(stdout, "try to find the group: %s\n", exec->additional_groups[i]);
-		struct group *gr = hyper_getgrnam(exec->additional_groups[i]);
-		if (gr == NULL) {
-			perror("can't find the group");
-			goto fail;
+		if (hyper_name_to_id(exec->additional_groups[i], &id)) {
+			groups[ngroups] = id;
+		} else {
+			struct group *gr = hyper_getgrnam(exec->additional_groups[i]);
+			if (gr == NULL) {
+				perror("can't find the group");
+				goto fail;
+			}
+			groups[ngroups] = gr->gr_gid;
 		}
-		groups[ngroups] = gr->gr_gid;
 		ngroups++;
 	}
 

--- a/src/util.c
+++ b/src/util.c
@@ -132,6 +132,18 @@ static unsigned long id_or_max(const char *name)
 	return id;
 }
 
+// Checks if the name provided is a numeric value and does the conversion.
+bool hyper_name_to_id(const char *name, unsigned long *val)
+{
+	char *ptr;
+	errno = 0;
+	long id = strtol(name, &ptr, 10);
+	if (name == ptr || id < 0 || (errno != 0 && id == 0) || *ptr != '\0')
+		return false;
+	*val = id;
+	return true;
+}
+
 // the same as getpwnam(), but it only parses /etc/passwd and allows name to be id string
 struct passwd *hyper_getpwnam(const char *name)
 {

--- a/src/util.h
+++ b/src/util.h
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <grp.h>
 #include <pwd.h>
+#include <stdbool.h>
 #include "../config.h"
 
 struct hyper_pod;
@@ -36,6 +37,7 @@ int hyper_setfd_nonblock(int fd);
 int hyper_socketpair(int domain, int type, int protocol, int sv[2]);
 void hyper_shutdown();
 int hyper_insmod(char *module);
+bool hyper_name_to_id(const char *name, unsigned long *val);
 struct passwd *hyper_getpwnam(const char *name);
 struct group *hyper_getgrnam(const char *name);
 int hyper_getgrouplist(const char *user, gid_t group, gid_t *groups, int *ngroups);


### PR DESCRIPTION
This patch adds numeric gids in the additional groups list without
checking if they exist. This is behaviour that docker expects.
Fixes part of #250.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>