### PR TITLE
update the lvm download link in travis configure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ before_install:
   - sudo mkdir -p /usr/include/linux
   - sudo cp /usr/src/linux-headers-$(uname -r)/include/uapi/linux/vm_sockets.h /usr/include/linux
   - cd `mktemp -d`
-  - wget https://git.fedorahosted.org/cgit/lvm2.git/snapshot/lvm2-2_02_131.tar.xz
-  - tar xf lvm2-2_02_131.tar.xz
-  - cd lvm2-2_02_131
+  - wget ftp://sources.redhat.com/pub/lvm2/LVM2.2.02.131.tgz
+  - tar xf LVM2.2.02.131.tgz
+  - cd LVM2.2.02.131
   - ./configure && make device-mapper && sudo make install
 
 script:


### PR DESCRIPTION
The previous fedora hosting has retired.

Signed-off-by: Lai Jiangshan <jiangshanlai@gmail.com>