### PR TITLE
build: add --with-custom_kernel configure flag

### DIFF
--- a/build/Makefile.am
+++ b/build/Makefile.am
@@ -1,5 +1,9 @@
 all-local: initrd
 
+if WITH_KMODULES
+export INCLUDE_KMODULES=1
+endif
+
 if WITH_VBOX
 initrd-local:
 	bash ./make-initrd.sh vbox

--- a/build/make-initrd.sh
+++ b/build/make-initrd.sh
@@ -19,11 +19,14 @@ cp socat /tmp/hyperstart-rootfs/sbin/
 cp libm.so.6 /tmp/hyperstart-rootfs/lib64/
 cp mount.nfs /tmp/hyperstart-rootfs/sbin/mount.nfs4
 
-if [ "$1"x = "aarch64"x ]; then
-	echo "build hyperstart for aarch64"
-	tar -xf modules_aarch64.tar -C /tmp/hyperstart-rootfs/lib/modules
-else
-	tar -xf modules.tar -C /tmp/hyperstart-rootfs/lib/modules
+if [ "$INCLUDE_KMODULES"x == "1"x ]; then
+	if [ "$1"x = "aarch64"x ]; then
+		echo "build hyperstart for aarch64"
+		tar -xf modules_aarch64.tar -C \
+			/tmp/hyperstart-rootfs/lib/modules
+	else
+		tar -xf modules.tar -C /tmp/hyperstart-rootfs/lib/modules
+	fi
 fi
 
 # create symlinks to busybox and iptables

--- a/configure.ac
+++ b/configure.ac
@@ -73,6 +73,14 @@ AS_IF([test "x$enable_daemon" = "xno"],[SYSTEMD_SYSTEMUNIT=no])
 AC_SUBST(SYSTEMD_SYSTEMUNIT)
 AM_CONDITIONAL(SYSTEMD, test "x${SYSTEMD_SYSTEMUNIT}" != "xno" )
 
+AC_ARG_WITH([kmodules],
+	    AS_HELP_STRING([--without-kmodules],
+			   [Do not include kernel modules in the rootfs]), [],
+			   [])
+# by default kernel modules are included
+AS_IF([test "x$with_kmodules" = "x"],[with_kmodules=yes])
+AM_CONDITIONAL([WITH_KMODULES], [test "x$with_kmodules" = "xyes"])
+
 AC_CHECK_FILE([/usr/include/linux/vm_sockets.h],
 	      [have_vsock=yes], [have_vsock=no])
 if test "x$have_vsock" == "xyes"; then
@@ -94,6 +102,7 @@ AC_MSG_RESULT([
 
 	with-vbox:	${with_vbox}
 	with-aarch64:	${with_aarch64}
+	with-kmodules:  ${with_kmodules}
 
 	vsock-support:  ${have_vsock}
 


### PR DESCRIPTION
Which can be used to exclude kernel modules from rootfs in
the image building phase.

Signed-off-by: Dmitry Voytik <dmitry.voytik@huawei.com>