### PR TITLE
hyper_get/send_type by eventfd

### DIFF
--- a/src/container.c
+++ b/src/container.c
@@ -14,6 +14,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <dirent.h>
+#include <sys/eventfd.h>
 
 #include "util.h"
 #include "hyper.h"
@@ -517,8 +518,8 @@ static int hyper_rescan_scsi(void)
 struct hyper_container_arg {
 	struct hyper_container	*c;
 	struct hyper_pod	*pod;
-	int			pipe[2];
-	int			pipens[2];
+	int			mntns_referenced_efd;
+	int			container_inited_efd;
 };
 
 static int hyper_setup_container_rootfs(void *data)
@@ -527,10 +528,9 @@ static int hyper_setup_container_rootfs(void *data)
 	struct hyper_container *container = arg->c;
 	char root[512], rootfs[512];
 	int setup_dns;
-	uint32_t type;
 
 	/* wait for ns-opened ready message */
-	if (hyper_get_type(arg->pipens[0], &type) < 0 || type != READY) {
+	if (hyper_eventfd_recv(arg->mntns_referenced_efd) < 0) {
 		fprintf(stderr, "wait for /proc/self/ns/mnt opened failed\n");
 		goto fail;
 	}
@@ -669,12 +669,14 @@ static int hyper_setup_container_rootfs(void *data)
 		goto fail;
 	}
 
-	hyper_send_type(arg->pipe[1], READY);
+	fprintf(stdout, "hyper send container inited event: normal\n");
+	hyper_eventfd_send(arg->container_inited_efd, HYPER_EVENTFD_NORMAL);
 	fflush(NULL);
 	_exit(0);
 
 fail:
-	hyper_send_type(arg->pipe[1], ERROR);
+	fprintf(stderr, "hyper send container inited event: error\n");
+	hyper_eventfd_send(arg->container_inited_efd, HYPER_EVENTFD_ERROR);
 	_exit(125);
 }
 
@@ -704,19 +706,20 @@ int hyper_setup_container(struct hyper_container *container, struct hyper_pod *p
 	struct hyper_container_arg arg = {
 		.c	= container,
 		.pod	= pod,
-		.pipe	= {-1, -1},
-		.pipens = {-1, -1},
+		.mntns_referenced_efd	= -1,
+		.container_inited_efd 	= -1,
 	};
 	int flags = CLONE_NEWNS | SIGCHLD;
 	char path[128];
 	void *stack;
-	uint32_t type;
 	int pid;
 
 	container->exec.pod = pod;
 
-	if (pipe2(arg.pipe, O_CLOEXEC) < 0 || pipe2(arg.pipens, O_CLOEXEC) < 0) {
-		perror("create pipe between pod init execcmd failed");
+	arg.mntns_referenced_efd = eventfd(0, EFD_CLOEXEC);
+	arg.container_inited_efd = eventfd(0, EFD_CLOEXEC);
+	if (arg.mntns_referenced_efd < 0 || arg.container_inited_efd < 0) {
+		perror("create eventfd between pod init execcmd failed");
 		goto fail;
 	}
 
@@ -749,26 +752,23 @@ int hyper_setup_container(struct hyper_container *container, struct hyper_pod *p
 		perror("open container mount ns failed");
 		goto fail;
 	}
-	hyper_send_type(arg.pipens[1], READY);
+	fprintf(stdout, "hyper send mntns referenced event: normal\n");
+	hyper_eventfd_send(arg.mntns_referenced_efd, HYPER_EVENTFD_NORMAL);
 
 	/* wait for ready message */
-	if (hyper_get_type(arg.pipe[0], &type) < 0 || type != READY) {
+	if (hyper_eventfd_recv(arg.container_inited_efd) < 0) {
 		fprintf(stderr, "wait for setup container rootfs failed\n");
 		goto fail;
 	}
 
-	close(arg.pipe[0]);
-	close(arg.pipe[1]);
-	close(arg.pipens[0]);
-	close(arg.pipens[1]);
+	close(arg.mntns_referenced_efd);
+	close(arg.container_inited_efd);
 	return 0;
 fail:
 	close(container->ns);
 	container->ns = -1;
-	close(arg.pipe[0]);
-	close(arg.pipe[1]);
-	close(arg.pipens[0]);
-	close(arg.pipens[1]);
+	close(arg.mntns_referenced_efd);
+	close(arg.container_inited_efd);
 	return -1;
 }
 
@@ -791,10 +791,11 @@ struct hyper_container *hyper_find_container(struct hyper_pod *pod, const char *
 
 static void hyper_cleanup_container_mounts(struct hyper_container *container, struct hyper_pod *pod)
 {
-	int pid, pipe[2] = {-1, -1};
+	int pid, efd = -1;
 
-	if (pipe2(pipe, O_CLOEXEC) < 0) {
-		perror("create pipe for unmount failed");
+	efd = eventfd(0, EFD_CLOEXEC);
+	if (efd < 0) {
+		perror("create eventfd for unmount failed");
 		return;
 	}
 
@@ -804,23 +805,25 @@ static void hyper_cleanup_container_mounts(struct hyper_container *container, st
 		goto out;
 	} else if (pid == 0) {
 		if (hyper_enter_sandbox(pod, -1) < 0) {
-			hyper_send_type(pipe[1], -1);
+			fprintf(stderr, "hyper send enter sandbox event: error\n");
+			hyper_eventfd_send(efd, HYPER_EVENTFD_ERROR);
 			_exit(-1);
 		}
 		if (setns(container->ns, CLONE_NEWNS) < 0) {
 			perror("fail to enter container ns");
-			hyper_send_type(pipe[1], -1);
+			fprintf(stderr, "hyper send enter container ns event: error\n");
+			hyper_eventfd_send(efd, HYPER_EVENTFD_ERROR);
 			_exit(-1);
 		}
 		hyper_unmount_all();
-		hyper_send_type(pipe[1], 0);
+		fprintf(stdout, "hyper send cleanup container mounts event: normal\n");
+		hyper_eventfd_send(efd, HYPER_EVENTFD_NORMAL);
 		_exit(0);
 	}
-	hyper_get_type(pipe[0], (uint32_t *)&pid);
+	hyper_eventfd_recv(efd);
 
 out:
-	close(pipe[0]);
-	close(pipe[1]);
+	close(efd);
 }
 
 void hyper_cleanup_container(struct hyper_container *c, struct hyper_pod *pod)

--- a/src/hyper.h
+++ b/src/hyper.h
@@ -87,7 +87,7 @@ static inline int hyper_create(char *hyper_path)
 	return 0;
 }
 
-int hyper_enter_sandbox(struct hyper_pod *pod, int pidpipe);
+int hyper_enter_sandbox(struct hyper_pod *pod, int pefd);
 void hyper_pod_destroyed(struct hyper_pod *pod, int failed);
 int hyper_ctl_append_msg(struct hyper_event *he, uint32_t type, uint8_t *data, uint32_t len);
 

--- a/src/net.c
+++ b/src/net.c
@@ -68,37 +68,6 @@ int hyper_send_data(int fd, uint8_t *data, uint32_t len)
 	return 0;
 }
 
-int hyper_send_type(int fd, uint32_t type)
-{
-	uint8_t buf[4];
-
-	fprintf(stdout, "hyper send type %d\n", type);
-
-	hyper_set_be32(buf, type);
-
-	return hyper_send_data(fd, buf, 4);
-}
-
-int hyper_get_type(int fd, uint32_t *type)
-{
-	int len = 0, size;
-	uint8_t buf[4];
-
-	while (len < 4) {
-		size = read(fd, buf + len, 4 - len);
-		if (size <= 0) {
-			if (errno == EINTR)
-				continue;
-			perror("hyper_get_type failed");
-			return -1;
-		}
-		len += size;
-	}
-
-	*type = hyper_get_be32(buf);
-	return 0;
-}
-
 int hyper_send_data_block(int fd, uint8_t *data, uint32_t len)
 {
 	int ret, flags;

--- a/src/net.h
+++ b/src/net.h
@@ -50,8 +50,6 @@ int hyper_cmd_setup_interface(char *json, int length);
 int hyper_cmd_setup_route(char *json, int length);
 int hyper_setup_dns(struct hyper_pod *pod);
 int hyper_setup_hostname(struct hyper_pod *pod);
-int hyper_get_type(int fd, uint32_t *type);
-int hyper_send_type(int fd, uint32_t type);
 int hyper_send_data_block(int fd, uint8_t *data, uint32_t len);
 int hyper_send_data(int fd, uint8_t *data, uint32_t len);
 #endif

--- a/src/util.c
+++ b/src/util.c
@@ -874,3 +874,42 @@ int hyper_mount_nfs(char *server, char *mountpoint)
 
 	return hyper_cmd(cmd);
 }
+
+int64_t hyper_eventfd_recv(int fd)
+{
+	int64_t type;
+	int size;
+
+	while (1) {
+		size = read(fd, &type, sizeof(type));
+		if (size != sizeof(type)) {
+			if (errno == EINTR)
+				continue;
+
+			perror("hyper_eventfd_recv failed");
+			return -1;
+		}
+		break;
+	}
+
+	return type;
+}
+
+int hyper_eventfd_send(int fd, int64_t type)
+{
+	int size;
+
+	while (1) {
+		size = write(fd, &type, sizeof(type));
+		if (size != sizeof(type)) {
+			if (errno == EINTR)
+				continue;
+
+			perror("hyper_eventfd_send failed");
+			return -1;
+		}
+		break;
+	}
+
+	return 0;
+}

--- a/src/util.h
+++ b/src/util.h
@@ -5,7 +5,11 @@
 #include <grp.h>
 #include <pwd.h>
 #include <stdbool.h>
+#include <limits.h>
 #include "../config.h"
+
+#define HYPER_EVENTFD_NORMAL 1
+#define HYPER_EVENTFD_ERROR INT_MIN
 
 struct hyper_pod;
 struct env;
@@ -44,4 +48,6 @@ struct group *hyper_getgrnam(const char *name);
 int hyper_getgrouplist(const char *user, gid_t group, gid_t *groups, int *ngroups);
 ssize_t nonblock_read(int fd, void *buf, size_t count);
 int hyper_mount_nfs(char *server, char *mountpoint);
+int64_t hyper_eventfd_recv(int fd);
+int hyper_eventfd_send(int fd, int64_t type);
 #endif


### PR DESCRIPTION
Except `hyper_run_process` in exec.c, the use of eventfd in this case may be tricky, so still use pipe.

Signed-off-by: Yao Zengzeng <yaozengzeng@zju.edu.cn>