### PR TITLE
Print version and git commit in hyperstart

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,5 @@
-AM_CFLAGS = -Wall -Werror
+COMMIT=`git describe --dirty --always --tags 2> /dev/null || true`
+AM_CFLAGS = -Wall -Werror -DVERSIONCOMMIT=\""$(VERSION), commit: $(COMMIT)"\"
 bin_PROGRAMS=hyperstart
 hyperstart_SOURCES=init.c jsmn.c net.c util.c parse.c parson.c container.c exec.c event.c portmapping.c
 if HAVE_VSOCK

--- a/src/init.c
+++ b/src/init.c
@@ -1460,6 +1460,9 @@ static int hyper_loop(void)
 static int hyper_setup_init_process(void)
 {
 	/* mount the base file systems */
+	printf("\n<**********************************************************************\n");
+	printf("< Hyperstart Version: %s\n", VERSIONCOMMIT);
+	printf("<**********************************************************************\n");
 	if (mount("proc", "/proc", "proc", MS_NOSUID| MS_NODEV| MS_NOEXEC, NULL) == -1) {
 		perror("mount proc failed");
 		return -1;


### PR DESCRIPTION
When start container, print git commit in hyperstart to show accurate
version number.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>