### PR TITLE
retry blockdev mount

### DIFF
--- a/src/container.c
+++ b/src/container.c
@@ -134,7 +134,7 @@ static int container_setup_volume(struct hyper_container *container)
 			if (!strcmp(vol->fstype, "xfs"))
 				options = "nouuid";
 
-			if (mount(dev, path, vol->fstype, 0, options) < 0) {
+			if (hyper_mount_blockdev(dev, path, vol->fstype, options) < 0) {
 				perror("mount volume device failed");
 				return -1;
 			}
@@ -588,7 +588,7 @@ static int hyper_setup_container_rootfs(void *data)
 		if (!strncmp(container->fstype, "xfs", strlen("xfs")))
 			options = "nouuid";
 
-		if (mount(dev, root, container->fstype, 0, options) < 0) {
+		if (hyper_mount_blockdev(dev, root, container->fstype, options) < 0) {
 			perror("mount device failed");
 			goto fail;
 		}

--- a/src/util.c
+++ b/src/util.c
@@ -913,3 +913,21 @@ int hyper_eventfd_send(int fd, int64_t type)
 
 	return 0;
 }
+
+/* block device might not be present when we call mount. Sleep a bit in such case */
+int hyper_mount_blockdev(const char *dev, const char *root, const char *fstype, const char *options)
+{
+	int i, retry = 5;
+
+	for (i = 0; i < retry; i++) {
+		if (mount(dev, root, fstype, 0, options) < 0) {
+			if (errno != ENOENT)
+				return -1;
+			usleep(20000);
+			continue;
+		}
+		return 0;
+	}
+
+	return -1;
+}

--- a/src/util.h
+++ b/src/util.h
@@ -50,4 +50,5 @@ ssize_t nonblock_read(int fd, void *buf, size_t count);
 int hyper_mount_nfs(char *server, char *mountpoint);
 int64_t hyper_eventfd_recv(int fd);
 int hyper_eventfd_send(int fd, int64_t type);
+int hyper_mount_blockdev(const char *dev, const char *root, const char *fstype, const char *options);
 #endif


### PR DESCRIPTION
block devices are hotplugged to guest vm. It needs sometime for the
guest kernel to initialize. If we proceed too soon to mount, mount can
fail with ENOENT. Retry a bit in such case.

Fixes: https://github.com/hyperhq/hyperd/issues/601