### PR TITLE
do not clean up container mountpoints when cleaning up running containers

### DIFF
--- a/src/container.h
+++ b/src/container.h
@@ -1,6 +1,8 @@
 #ifndef _CONTAINER_H_
 #define _CONTAINER_H_
 
+#include <stdbool.h>
+
 #include "exec.h"
 #include "api.h"
 
@@ -57,7 +59,7 @@ struct hyper_pod;
 
 int hyper_setup_container(struct hyper_container *container, struct hyper_pod *pod);
 struct hyper_container *hyper_find_container(struct hyper_pod *pod, const char *id);
-void hyper_cleanup_container(struct hyper_container *container, struct hyper_pod *pod);
+void hyper_cleanup_container(struct hyper_container *container, struct hyper_pod *pod, bool sync_only);
 void hyper_cleanup_mounts(struct hyper_pod *pod);
 void hyper_free_container(struct hyper_container *c);
 

--- a/src/exec.c
+++ b/src/exec.c
@@ -746,7 +746,7 @@ static int hyper_release_exec(struct hyper_exec *exec)
 			/* shutdown vm manually, hyper doesn't care the pod finished codes */
 			hyper_pod_destroyed(exec->pod, 0);
 		}
-		hyper_cleanup_container(container_of(exec, struct hyper_container, exec), exec->pod);
+		hyper_cleanup_container(container_of(exec, struct hyper_container, exec), exec->pod, true);
 		return 0;
 	}
 

--- a/src/init.c
+++ b/src/init.c
@@ -643,7 +643,7 @@ static int hyper_new_container(struct hyper_pod *pod, char *json, int length)
 
 	if (hyper_has_container(pod, c->id)) {
 		fprintf(stderr, "container id conflicts");
-		hyper_cleanup_container(c, pod);
+		hyper_cleanup_container(c, pod, false);
 		return -1;
 	}
 
@@ -654,7 +654,7 @@ static int hyper_new_container(struct hyper_pod *pod, char *json, int length)
 
 	if (ret < 0) {
 		//TODO full grace cleanup
-		hyper_cleanup_container(c, pod);
+		hyper_cleanup_container(c, pod, false);
 	} else {
 		pod->remains++;
 	}
@@ -733,7 +733,7 @@ static int hyper_remove_container(struct hyper_pod *pod, char *json, int length)
 		goto out;
 	}
 
-	hyper_cleanup_container(c, pod);
+	hyper_cleanup_container(c, pod, true);
 
 	ret = 0;
 out:


### PR DESCRIPTION
It seems 9p has issues with umount propagation w.r.t. bind mounts. As
a result, when we umount 9p bind mounts in hyper_cleanup_container(),
the 9p share turns read-only.

This PR works around it by just calling sync() to make sure data is
persistent when cleaning up running containers. Hanging superblocks are
cleaned up by kernel when mntns is closed.

Also clean up pty mountpoint as it is created outside of the container namespace.