### PR TITLE
umount pty when cleaning up containers

### DIFF
--- a/src/container.c
+++ b/src/container.c
@@ -708,6 +708,15 @@ static int hyper_setup_pty(struct hyper_container *c)
 	return 0;
 }
 
+static void hyper_cleanup_pty(struct hyper_container *c)
+{
+	char path[512];
+
+	sprintf(path, "/tmp/hyper/%s/devpts/", c->id);
+	if (umount(path) < 0)
+		perror("clean up container pty failed");
+}
+
 int hyper_setup_container(struct hyper_container *container, struct hyper_pod *pod)
 {
 	int stacksize = getpagesize() * 42;
@@ -838,6 +847,7 @@ void hyper_cleanup_container(struct hyper_container *c, struct hyper_pod *pod)
 {
 	hyper_cleanup_container_mounts(c, pod);
 	close(c->ns);
+	hyper_cleanup_pty(c);
 	hyper_cleanup_container_portmapping(c, pod);
 	hyper_free_container(c);
 }


### PR DESCRIPTION
pty is mounted outside of container namespace. It needs to be cleaned
up outside as well.