### PR TITLE
share /dev/shm for all the containers in the pod

### DIFF
--- a/src/container.c
+++ b/src/container.c
@@ -307,8 +307,8 @@ static int container_setup_mount(struct hyper_container *container)
 		return -1;
 	}
 
-	if (mount("tmpfs", "./dev/shm/", "tmpfs", MS_NOSUID| MS_NODEV, NULL) < 0) {
-		perror("mount shm failed");
+	if (mount("/tmp/hyper/shm", "./dev/shm/", "tmpfs", MS_BIND, NULL) < 0) {
+		perror("bind mount shared shm failed");
 		return -1;
 	}
 


### PR DESCRIPTION
fix #323

All containers in the pod share the same ipc namespace. However,
posix ipc primitives are shm_open() family whose behaviors
implemented in glibc are to create&share the shm objects within
/dev/shm (or scans /proceed/mounts for any tmpfs if /dev/shm
is not tmpfs).
So we have to create the only one tmpfs mount and share it
to all the containers.

Signed-off-by: Lai Jiangshan <jiangshanlai@gmail.com>