### PR TITLE
Fix guest kernel crashed when hyperstart handle SETUPROUTE

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -302,7 +302,7 @@ static int hyper_setup_route(struct rtnl_handle *rth,
 		char buf[1024];
 	} req;
 
-	if (!rt->dst) {
+	if (!rt || !rt->dst) {
 		fprintf(stderr, "route dest is null\n");
 		return -1;
 	}

--- a/src/parse.c
+++ b/src/parse.c
@@ -1023,6 +1023,12 @@ int hyper_parse_setup_routes(struct hyper_route **routes, uint32_t *r_num, char 
 	jsmntok_t *toks = NULL;
 	int found = 0;
 
+	/*
+	 * If we could not find routes from JSON, we have to set r_num to 0,
+	 * this will avid returning a random number for r_num.
+	 */
+	*r_num = 0;
+
 realloc:
 	toks = realloc(toks, toks_num * sizeof(jsmntok_t));
 	if (toks == NULL) {


### PR DESCRIPTION
When we're running runv without containerd with kvmtool. There is not network
support. But hyperstart still get a command to do SETUPROUTE. But in this case
the route list is empty. We hadn't checked this case, a NULL pointer reference
had crashed the guest kernel.

hyper_ctlmsg_handle SETUPROUTE
init[1]: unhandled level 2 translation fault (11) at 0x00000000, esr 0x92000006
pgd = ffffffc005767000
[00000000] *pgd=0000000085769003, *pud=0000000085769003
, *pmd=0000000000000000
CPU: 0 PID: 1 Comm: init Not tainted 4.9.36 #3
Hardware name: linux,dummy-virt (DT)
task: ffffffc00744ad00 task.stack: ffffffc00744c000
PC is at 0x406ba8
LR is at 0x4079f0
pc : [<0000000000406ba8>] lr : [<00000000004079f0>] pstate: 60000000
sp : 0000007ffec98cb0
x29: 0000007ffec98cb0 x28: 0000000000000000
x27: 000000000042c000 x26: 000000002f2131c0
x25: 0000000000000015 x24: 0000000000416000
x23: 000000000042c000 x22: 0000007ffec99170
x21: 000000000042c000 x20: 000000000042c000
x19: 0000000000000000 x18: 0000000000000001
x17: 0000007f95058988 x16: 000000000042c2a8
x15: 0000000000000001 x14: 0000000000000003
x13: 0000000000417b58 x12: 00000000ffffffff
x11: 000000000000000a x10: 0000000000000000
x9 : 0000000000000001 x8 : 00000000ffffffff
x7 : 0000000000000002 x6 : 000000002f2131d0
x5 : 0000000000000001 x4 : 0000000000000001
x3 : 0000000000000000 x2 : 000000000042c448
x1 : 000000000042c640 x0 : 0000000000000000
Kernel panic - not syncing: Attempted to kill init! exitcode=0x0000000b

Just add the empty route list check to fix this bug.