### PR TITLE
Change exec default home dir

### DIFF
--- a/src/exec.c
+++ b/src/exec.c
@@ -535,7 +535,7 @@ static int hyper_do_exec_cmd(struct hyper_exec *exec, int pid_efd, int process_i
 	clearenv();
 
 	// set early env. the container env config can overwrite it
-	setenv("HOME", "/root", 1);
+	setenv("HOME", "/", 1);
 	setenv("HOSTNAME", exec->pod->hostname, 1);
 	if (exec->tty)
 		setenv("TERM", "xterm", 1);


### PR DESCRIPTION
*  add default home dir for exec
```
    before this pr:
    [root@localhost ~]# docker exec -ti -u 715:715 hasnoname bash
    bash: /root/.bashrc: Permission denied
    bash-4.2$
    
    we can see the denied message.
    
    after this pr:
    [root@localhost ~]# docker exec -ti -u 715:715 hasnoname bash
    bash-4.2$ exit
    exit
```
* don't get gid if get uid using successfully hyper_getpwnam